### PR TITLE
test: enable sanity test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,10 @@ jobs:
       script:
         - make
         - make integration-test
+    - stage: test
+      name: "sanity test"
+      install:
+        - sudo apt update && sudo apt install cifs-utils procps -y
+      script:
+        - make
+        - make sanity-test

--- a/pkg/smb/controllerserver.go
+++ b/pkg/smb/controllerserver.go
@@ -25,12 +25,26 @@ import (
 	"k8s.io/klog"
 )
 
+// CreateVolume not implemented, only for sanity test pass
 func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	volumeCapabilities := req.GetVolumeCapabilities()
+	if len(volumeCapabilities) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "CreateVolume Volume capabilities must be provided")
+	}
+	return &csi.CreateVolumeResponse{
+		Volume: &csi.Volume{
+			VolumeId:      "volumeID",
+			CapacityBytes: req.GetCapacityRange().GetRequiredBytes(),
+		},
+	}, nil
 }
 
+// DeleteVolume not implemented, only for sanity test pass
 func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	if len(req.GetVolumeId()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "Volume ID missing in request")
+	}
+	return &csi.DeleteVolumeResponse{}, nil
 }
 
 func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
@@ -51,7 +65,15 @@ func (d *Driver) ControllerGetCapabilities(ctx context.Context, req *csi.Control
 }
 
 func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	if len(req.GetVolumeId()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "Volume ID missing in request")
+	}
+	if req.GetVolumeCapabilities() == nil {
+		return nil, status.Error(codes.InvalidArgument, "Volume capabilities missing in request")
+	}
+
+	// supports all AccessModes, no need to check capabilities here
+	return &csi.ValidateVolumeCapabilitiesResponse{Message: ""}, nil
 }
 
 // GetCapacity returns the capacity of the total available storage pool

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -129,13 +129,15 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID missing in request")
 	}
-	targetPath := req.GetStagingTargetPath()
-	if len(targetPath) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "Staging target not provided")
-	}
+
 	volumeCapability := req.GetVolumeCapability()
 	if volumeCapability == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume capability not provided")
+	}
+
+	targetPath := req.GetStagingTargetPath()
+	if len(targetPath) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "Staging target not provided")
 	}
 
 	volumeID := req.GetVolumeId()

--- a/test/sanity/README.md
+++ b/test/sanity/README.md
@@ -1,8 +1,6 @@
 ## Sanity Tests
 Testing the SMB CSI driver using the [`sanity`](https://github.com/kubernetes-csi/csi-test/tree/master/pkg/sanity) package test suite.
 
-## Run Integration Tests Locally
-
 ### Run sanity tests
 ```
 make sanity-test

--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -44,4 +44,4 @@ _output/smbplugin --endpoint "$endpoint" --nodeid "$nodeid" -v=5 &
 
 echo 'Begin to run sanity test...'
 readonly CSI_SANITY_BIN='csi-test/cmd/csi-sanity/csi-sanity'
-"$CSI_SANITY_BIN" --ginkgo.v --ginkgo.noColor --csi.endpoint="$endpoint" --ginkgo.skip='should fail when the volume source snapshot is not found|should work'
+"$CSI_SANITY_BIN" --ginkgo.v --ginkgo.noColor --csi.endpoint="$endpoint" --ginkgo.skip='ValidateVolumeCapabilities|ControllerGetCapabilities|should work'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind test

**What this PR does / why we need it**:
test: enable sanity test

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
There is one sanity test should enable it later, need to figure out how to set volumeContext in `NodeStageVolume` in sanity test.

```
• Failure [0.003 seconds]
Node Service
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/tests.go:44
  should work [It]
  /root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/node.go:643

  Unexpected error:
      <*status.statusError | 0xc0001ecff0>: {
          Code: 3,
          Message: "source field is missing, current context: map[]",
          Details: nil,
          XXX_NoUnkeyedLiteral: {},
          XXX_unrecognized: nil,
          XXX_sizecache: 0,
      }
      rpc error: code = InvalidArgument desc = source field is missing, current context: map[]
  occurred

  /root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/node.go:740
------------------------------


Summarizing 1 Failure:

[Fail] Node Service [It] should work
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/node.go:740

Ran 16 of 72 Specs in 0.029 seconds
FAIL! -- 15 Passed | 1 Failed | 0 Pending | 56 Skipped
--- FAIL: TestSanity (0.04s)
```

**Release note**:
```
none
```
