### PR TITLE
make kubelet path configurable from helm values

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -27,7 +27,7 @@ $ helm search repo -l csi-driver-smb/
 ```
 
 ### Install a specific version of Helm chart
-Specify the version of the chart to be installed using the `--version` parameter. 
+Specify the version of the chart to be installed using the `--version` parameter.
 ```console
 helm install --name csi-driver-smb csi-driver-smb/csi-driver-smb --namespace kube-system --version v0.3.0
 ```
@@ -70,6 +70,8 @@ The following table lists the configurable parameters of the latest SMB CSI Driv
 | `windows.image.nodeDriverRegistrar.repository`    | windows csi-node-driver-registrar docker image             | mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar    |
 | `windows.image.nodeDriverRegistrar.tag`           | windows csi-node-driver-registrar docker image tag         | v1.2.1-alpha.1-windows-1809-amd64                                 |
 | `windows.image.nodeDriverRegistrar.pullPolicy`    | windows csi-node-driver-registrar image pull policy        | IfNotPresent                                                      |
+| `kubelet.linuxPath`                               | configure the kubelet path for Linux node                  | `/var/lib/kubelet`                                                |
+| `kubelet.windowsPath`                             | configure the kubelet path for Windows node                | `'C:\var\lib\kubelet'`                                            |
 
 ## Troubleshooting
 

--- a/charts/latest/csi-driver-smb/templates/csi-smb-node-windows.yaml
+++ b/charts/latest/csi-driver-smb/templates/csi-smb-node-windows.yaml
@@ -128,14 +128,14 @@ spec:
             type: ""
         - name: registration-dir
           hostPath:
-            path: C:\var\lib\kubelet\plugins_registry\
+            path: {{ .Values.kubelet.windowsPath }}\plugins_registry\
             type: Directory
         - name: kubelet-dir
           hostPath:
-            path: C:\var\lib\kubelet\
+            path: {{ .Values.kubelet.windowsPath }}\
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: C:\var\lib\kubelet\plugins\smb.csi.k8s.io\
+            path: {{ .Values.kubelet.windowsPath }}\plugins\smb.csi.k8s.io\
             type: DirectoryOrCreate
 {{- end -}}

--- a/charts/latest/csi-driver-smb/templates/csi-smb-node.yaml
+++ b/charts/latest/csi-driver-smb/templates/csi-smb-node.yaml
@@ -115,15 +115,15 @@ spec:
               memory: 20Mi
       volumes:
         - hostPath:
-            path: /var/lib/kubelet/plugins/smb.csi.k8s.io
+            path: {{ .Values.kubelet.linuxPath }}/plugins/smb.csi.k8s.io
             type: DirectoryOrCreate
           name: socket-dir
         - hostPath:
-            path: /var/lib/kubelet/
+            path: {{ .Values.kubelet.linuxPath }}/
             type: DirectoryOrCreate
           name: mountpoint-dir
         - hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: {{ .Values.kubelet.linuxPath }}/plugins_registry/
             type: DirectoryOrCreate
           name: registration-dir
 {{- end -}}

--- a/charts/latest/csi-driver-smb/values.yaml
+++ b/charts/latest/csi-driver-smb/values.yaml
@@ -43,3 +43,7 @@ windows:
       repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
       tag: v1.2.1-alpha.1-windows-1809-amd64
       pullPolicy: IfNotPresent
+
+kubelet:
+  linuxPath: /var/lib/kubelet
+  windowsPath: 'C:\var\lib\kubelet'


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Typically when setting kubernetes, the Kubelet path varies for different kind of setups. For example in Racher2 boxes, the Kubelet path is `/opt/rke/var/lib/kubelet/` not `/var/lib/kubelet/`

The changes in this PR help make the Kubelet path configurable from helm template 

**Which issue(s) this PR fixes**:
Fixes #69 

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
Ability to make Kubelet path configurable from helm template
```
