### PR TITLE
Lay foundations for re-enabling windows tests: Start CSI-Proxy as a background Job.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,10 +18,25 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v2
       - name: Build Test
         run: |
           make smb-windows
       - name: Run Windows Unit Tests
         run: |
+          # start the CSI Proxy before running tests on windows
+          Start-Job -Name CSIProx -ScriptBlock {
+            Invoke-WebRequest https://kubernetesartifacts.azureedge.net/csi-proxy/v0.2.1/binaries/csi-proxy.tar.gz -OutFile csi-proxy.tar.gz;
+            tar -xvf csi-proxy.tar.gz
+            .\bin\csi-proxy.exe --kubelet-csi-plugins-path $pwd --kubelet-pod-path $pwd
+          };
+
+          # Wait for the CSI Proxy to come up
+          Start-Sleep -Seconds 30;
+
+          # Print all the named pipes to make sure that CSI-Proxy's named-pipes are created.
+          Write-Output "Getting named pipes"
+          [System.IO.Directory]::GetFiles("\\.\\pipe\\")
+
+          # Start the tests
           go test -v -race ./pkg/...


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:
Currently we are skipping a lot of test cases in windows. This is because using a fakeMounter to test on windows is causing isues. This PR lays a basic foundations to run windows based tests related to node by running [CSI-Proxy](https://github.com/kubernetes-csi/csi-proxy) as a background job and the all the mount related operation will be handled by this proxy. For more in-depth design details for CSI-Proxy, please refer to the design doc: https://github.com/kubernetes/enhancements/blob/master/keps/sig-windows/20190714-windows-csi-support.md

**Which issue(s) this PR fixes**:

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

Added a script to `.github.com/workflows/windows.yml` that downloads and starts CSI-Proxy as windows background job.

**Release note**:
```
none
```
