### PR TITLE
Revert "fix: create nonroot user in Dockerfile"

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -1,4 +1,4 @@
-name: MacOS Build & Unit Test
+name: MacOS Unit Tests
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: Ubuntu Test
+name: Linux Unit tests
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: Windows Build & Unit Test
+name: Windows Unit Tests
 on:
   push:
     branches: [ master ]

--- a/charts/latest/csi-driver-smb/templates/csi-smb-controller.yaml
+++ b/charts/latest/csi-driver-smb/templates/csi-smb-controller.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          securityContext:
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/latest/csi-driver-smb/templates/csi-smb-node.yaml
+++ b/charts/latest/csi-driver-smb/templates/csi-smb-node.yaml
@@ -100,7 +100,6 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/csi-smb-controller.yaml
+++ b/deploy/csi-smb-controller.yaml
@@ -86,8 +86,6 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          securityContext:
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/csi-smb-node.yaml
+++ b/deploy/csi-smb-node.yaml
@@ -96,7 +96,6 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/pkg/smbplugin/Dockerfile
+++ b/pkg/smbplugin/Dockerfile
@@ -25,9 +25,5 @@ RUN clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfs
 LABEL maintainers="andyzhangx"
 LABEL description="SMB CSI Driver"
 
-# Create a nonroot user
-RUN useradd -u 10001 nonroot
-USER nonroot
-
 COPY ./_output/smbplugin /smbplugin
 ENTRYPOINT ["/smbplugin"]

--- a/pkg/smbplugin/dev.Dockerfile
+++ b/pkg/smbplugin/dev.Dockerfile
@@ -17,9 +17,5 @@ RUN apt-get update && apt-get install -y ca-certificates cifs-utils util-linux e
 LABEL maintainers="andyzhangx"
 LABEL description="SMB CSI Driver"
 
-# Create a nonroot user
-RUN useradd -u 10001 nonroot
-USER nonroot
-
 COPY ./_output/smbplugin /smbplugin
 ENTRYPOINT ["/smbplugin"]


### PR DESCRIPTION
Reverts kubernetes-csi/csi-driver-smb#124

Original PR did not improve the security, that PR is just for bypass security scanning, while would introduce various permission setting issue.