### PR TITLE
Backslash instead of slash

### DIFF
--- a/deploy/example/storageclass-smb.yaml
+++ b/deploy/example/storageclass-smb.yaml
@@ -5,7 +5,7 @@ metadata:
   name: smb
 provisioner: smb.csi.k8s.io
 parameters:
-  source: "//smb-server.default.svc.cluster.local/share"
+  source: "\\\\smb-server.default.svc.cluster.local\\share"
   csi.storage.k8s.io/node-stage-secret-name: "smbcreds"
   csi.storage.k8s.io/node-stage-secret-namespace: "default"
   createSubDir: "false"  # optional: create a sub dir for new volume


### PR DESCRIPTION
I stumbled upon this problem while trying `csi-driver-smb` together with `csi-proxy`.

The problem was the function `IsSmbMapped()` thinking the Volume was not mapped while testing it with `//server/share` (using Windows CIFS Share and not k8s internal one)

because: 

```
PS C:\> Get-SmbGlobalMapping

Status Local Path Remote Path
------ ---------- -----------
OK                \\10.1.2.5\share


PS C:\> Get-SmbGlobalMapping -RemotePath //10.1.2.5/share
Get-SmbGlobalMapping : No MSFT_SmbGlobalMapping objects found with property 'RemotePath' equal to '//10.1.2.5/share'.  Verify the value of
the property and retry.
At line:1 char:1
+ Get-SmbGlobalMapping -RemotePath //10.1.2.5/share
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (//10.1.2.5/share:String) [Get-SmbGlobalMapping], CimJobException
    + FullyQualifiedErrorId : CmdletizationQuery_NotFound_RemotePath,Get-SmbGlobalMapping

PS C:\> Get-SmbGlobalMapping -RemotePath \\10.1.2.5\share

Status Local Path Remote Path
------ ---------- -----------
OK                \\10.1.2.5\share
```


The function just returns false (as not Mapped) if it fails: [csi-proxy/IsSmbMapped#L17](https://github.com/kubernetes-csi/csi-proxy/blob/master/internal/os/smb/api.go#L17)