### PR TITLE
Remove SecurityContext with true value privileged field

### DIFF
--- a/deploy/csi-smb-node-windows.yaml
+++ b/deploy/csi-smb-node-windows.yaml
@@ -95,8 +95,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: kubelet-dir
               mountPath: "C:\\var\\lib\\kubelet"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
DaemonSet in Windows node is not allowed to perform privileged action so the privileged field in security context shouldn't be true.

fix: Bug Fixes 🐞

