### PR TITLE
feat: Add possibility to use mount option "nobrl" when mounting a volume

### DIFF
--- a/deploy/example/storageclass-smb.yaml
+++ b/deploy/example/storageclass-smb.yaml
@@ -13,6 +13,7 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-name: "smbcreds"
   csi.storage.k8s.io/node-stage-secret-namespace: "default"
   createSubDir: "false"  # optional: create a sub dir for new volume
+  nobrl: "false"  # optional: add "nobrl" mount option; use with caution
 reclaimPolicy: Retain  # only retain is supported
 volumeBindingMode: Immediate
 mountOptions:

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -7,6 +7,7 @@ Name | Meaning | Available Value | Mandatory | Default value
 --- | --- | --- | --- | ---
 source | Samba Server address | `//smb-server-address/sharename` </br>([Azure File](https://docs.microsoft.com/en-us/azure/storage/files/storage-files-introduction) format: `//accountname.file.core.windows.net/filesharename`) | Yes |
 createSubDir | create a sub dir for new volume | `true`, `false` | `false` |
+nobrl | specifies the mount option "nobrl" to avoid byte range locks being sent to the "cifs/smb" server. Use with caution! Applications which may rely on proper file lockings will experience malfunction or data loss. | `true`, `false` | `false` |
 csi.storage.k8s.io/node-stage-secret-name | secret name that stores `username`, `password`(`domain` is optional) | existing secret name |  Yes  |
 csi.storage.k8s.io/node-stage-secret-namespace | namespace where the secret is | k8s namespace  |  Yes  |
 

--- a/pkg/smb/smb.go
+++ b/pkg/smb/smb.go
@@ -31,6 +31,7 @@ import (
 const (
 	DriverName        = "smb.csi.k8s.io"
 	createSubDirField = "createsubdir"
+	nobrlField        = "nobrl"
 )
 
 // Driver implements all interfaces of CSI drivers

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -12,6 +12,6 @@ go get github.com/rexray/gocsi/csc
 ### Run integration tests
 ```console
 export GOBIN="/root/go/bin"
-make test-integration
+make integration-test
 ```
 

--- a/test/integration/run-test.sh
+++ b/test/integration/run-test.sh
@@ -50,7 +50,7 @@ trap cleanup EXIT
 sleep 5
 # set secret for csc node stage
 export X_CSI_SECRETS=username=username,"password=test"
-params='source="//0.0.0.0/share",createSubDir="true"'
+params='source="//0.0.0.0/share",createSubDir="true",nobrl="true"'
 # Begin to run CSI functions one by one
 echo 'Create volume test:'
 readonly value=$("$CSC_BIN" controller new --endpoint "$endpoint" --cap 1,block "$volname" --req-bytes 2147483648 --params "$params")
@@ -71,7 +71,7 @@ echo 'Mount volume test:'
 sleep 2
 
 echo "node stats test:"
-csc node stats --endpoint "$endpoint" "$volumeid:$target_path:$staging_target_path"
+"$CSC_BIN" node stats --endpoint "$endpoint" "$volumeid:$target_path:$staging_target_path"
 sleep 2
 
 echo 'Unmount volume test:'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility to use the mount flag "nobrl". In certain conditions it is required to make applications work properly (e.g. when storing sqlite database files on the mounted volume)

**Requirements**:
- [X] feat: Features 🌈
        docs: Documentation 📘
- [X] includes documentation

**Release note**:
```
The cifs mount flag "nobrl" can be used when volumes are mounted.
```
/kind feature
/kind documentation