### PR TITLE
Change samba server yaml using default sc to be more general

### DIFF
--- a/deploy/example/smb-provisioner/README.md
+++ b/deploy/example/smb-provisioner/README.md
@@ -20,9 +20,11 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-sm
 kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/deploy/example/smb-provisioner/smb-server-lb.yaml
 ```
 
-#### Option#2. Create a Samba Server deployment on Azure managed disk
+#### Option#2. Create a Samba Server deployment on network disk
+Default network disk in Azure is Azure managed disk and default one in GCE is persistent disk.
+
 ```console
-kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/deploy/example/smb-provisioner/smb-server-azuredisk.yaml
+kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/deploy/example/smb-provisioner/smb-server-networkdisk.yaml
 ```
 
 After deployment, a new service `smb-server` is created, file share path is `//smb-server.default.svc.cluster.local/share`

--- a/deploy/example/smb-provisioner/smb-server-networkdisk.yaml
+++ b/deploy/example/smb-provisioner/smb-server-networkdisk.yaml
@@ -16,14 +16,14 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: pvc-azuredisk-smbshare
+  name: pvc-networkdisk-smbshare
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 100Gi
-  storageClassName: default
+  storageClassName: default  # storage provider is Azure disk in Azure and persistent disk in GCE.
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -67,4 +67,4 @@ spec:
       volumes:
         - name: data-volume
           persistentVolumeClaim:
-            claimName: pvc-azuredisk-smbshare
+            claimName: pvc-networkdisk-smbshare


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
The samba server deployment using default storageclass works for both Azure disk and PD. Update the names in the yaml file and docs to point this out. 

**Special notes for your reviewer**:


**Release note**:
```
none
```
