### PR TITLE
fix registry prefix in push-manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ push-manifest:
 	docker manifest create --amend $(IMAGE_TAG) $(foreach osarch, $(ALL_OS_ARCH), $(IMAGE_TAG)-${osarch})
 	# add "os.version" field to windows images (based on https://github.com/kubernetes/kubernetes/blob/master/build/pause/Makefile)
 	set -x; \
-	registry_prefix=$(shell (echo ${REGISTRY} | grep -Eq ".*\/.*") && echo "docker.io/" || echo ""); \
+	registry_prefix=$(shell (echo ${REGISTRY} | grep -v "mcr\|gcr\|azurecr" | grep -Eq ".*\/.*") && echo "docker.io/" || echo ""); \
 	manifest_image_folder=`echo "$${registry_prefix}${IMAGE_TAG}" | sed "s|/|_|g" | sed "s/:/-/"`; \
 	for arch in $(ALL_ARCH.windows); do \
 		for osversion in $(ALL_OSVERSIONS.windows); do \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
registry_fix shall be empty for non dockerhub registries. Currently it returns docker.io for some registry like gcr.io/xyz

**Special notes for your reviewer**:


**Release note**:
```
none
```
