### PR TITLE
Change to use bosko project gcr registry for e2e test

### DIFF
--- a/test/run-e2e-test.sh
+++ b/test/run-e2e-test.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
+GCE_PROJECT=$(gcloud config get-value project)
 
 setup_e2e() {
     # If run in prow, need to use kubernetes_e2e.py to set up the project and kubernetes automatically.
@@ -27,6 +28,7 @@ setup_e2e() {
 }
 
 export TEST_WINDOWS=true
+export REGISTRY=gcr.io/$GCE_PROJECT
 
 setup_e2e
 make -C $PROJECT_ROOT e2e-test


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Update the test script to use bosko project gcr registry

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
