### PR TITLE
feat: add subDir in storage class parameters

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -13,4 +13,4 @@ jobs:
               uses: golangci/golangci-lint-action@v2
               with:
                   version: v1.29
-                  args: -E=gofmt,golint,misspell --timeout=30m0s
+                  args: -E=gofmt,deadcode,unused,varcheck,ineffassign,golint,misspell --timeout=30m0s

--- a/deploy/example/e2e_usage.md
+++ b/deploy/example/e2e_usage.md
@@ -22,7 +22,7 @@ provisioner: smb.csi.k8s.io
 parameters:
   source: "//smb-server.default.svc.cluster.local/share"
   # if csi.storage.k8s.io/provisioner-secret is provided, will create a sub directory
-  # with PV name under source
+  # with PV name by default under source
   csi.storage.k8s.io/provisioner-secret-name: "smbcreds"
   csi.storage.k8s.io/provisioner-secret-namespace: "default"
   csi.storage.k8s.io/node-stage-secret-name: "smbcreds"
@@ -52,6 +52,8 @@ provisioner: smb.csi.k8s.io
 parameters:
   # On Windows, "*.default.svc.cluster.local" could not be recognized by csi-proxy
   source: "//smb-server.default.svc.cluster.local/share"
+  # if csi.storage.k8s.io/provisioner-secret is provided, will create a sub directory
+  # with PV name by default under source
   csi.storage.k8s.io/provisioner-secret-name: "smbcreds"
   csi.storage.k8s.io/provisioner-secret-namespace: "default"
   csi.storage.k8s.io/node-stage-secret-name: "smbcreds"

--- a/deploy/example/storageclass-smb.yaml
+++ b/deploy/example/storageclass-smb.yaml
@@ -8,7 +8,7 @@ parameters:
   # On Windows, "*.default.svc.cluster.local" could not be recognized by csi-proxy
   source: "//smb-server.default.svc.cluster.local/share"
   # if csi.storage.k8s.io/provisioner-secret is provided, will create a sub directory
-  # with PV name under source
+  # with PV name by default under source
   csi.storage.k8s.io/provisioner-secret-name: "smbcreds"
   csi.storage.k8s.io/provisioner-secret-namespace: "default"
   csi.storage.k8s.io/node-stage-secret-name: "smbcreds"

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -6,6 +6,7 @@
 Name | Meaning | Available Value | Mandatory | Default value
 --- | --- | --- | --- | ---
 source | Samba Server address | `//smb-server-address/sharename` </br>([Azure File](https://docs.microsoft.com/en-us/azure/storage/files/storage-files-introduction) format: `//accountname.file.core.windows.net/filesharename`) | Yes |
+subDir | existing sub directory under smb share |  | No | sub directory must exist otherwise mount would fail
 csi.storage.k8s.io/provisioner-secret-name | secret name that stores `username`, `password`(`domain` is optional); if secret is provided, driver will create a sub directory with PV name under `source` | existing secret name |  No  |
 csi.storage.k8s.io/provisioner-secret-namespace | namespace where the secret is | existing secret namespace |  No  |
 csi.storage.k8s.io/node-stage-secret-name | secret name that stores `username`, `password`(`domain` is optional) | existing secret name |  Yes  |
@@ -17,5 +18,11 @@ csi.storage.k8s.io/node-stage-secret-namespace | namespace where the secret is |
 Name | Meaning | Available Value | Mandatory | Default value
 --- | --- | --- | --- | ---
 volumeAttributes.source | Samba Server address | `//smb-server-address/sharename` </br>([Azure File](https://docs.microsoft.com/en-us/azure/storage/files/storage-files-introduction) format: `//accountname.file.core.windows.net/filesharename`) | Yes |
+volumeAttributes.subDir | existing sub directory under smb share |  | No | sub directory must exist otherwise mount would fail
 nodeStageSecretRef.name | secret name that stores `username`, `password`(`domain` is optional) | existing secret name |  Yes  |
 nodeStageSecretRef.namespace | namespace where the secret is | k8s namespace  |  Yes  |
+
+ - Use `kubectl create secret` to create `smbcreds` secret to store Samba Server username, password
+```console
+kubectl create secret generic smbcreds --from-literal username=USERNAME --from-literal password="PASSWORD"
+```

--- a/pkg/smb/smb.go
+++ b/pkg/smb/smb.go
@@ -30,7 +30,12 @@ import (
 
 const (
 	DefaultDriverName = "smb.csi.k8s.io"
-	paramSource       = "source"
+	usernameField     = "username"
+	passwordField     = "password"
+	sourceField       = "source"
+	subDirField       = "subdir"
+	domainField       = "domain"
+	defaultDomainName = "AZURE"
 )
 
 // Driver implements all interfaces of CSI drivers

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -332,7 +332,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test := testsuites.DynamicallyProvisionedPodWithMultiplePVsTest{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: defaultStorageClassParameters,
+			StorageClassParameters: subDirStorageClassParameters,
 		}
 		test.Run(cs, ns)
 	})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -54,6 +54,14 @@ var (
 		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
 		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
 	}
+	subDirStorageClassParameters = map[string]string{
+		"source": "//smb-server.default.svc.cluster.local/",
+		"subDir": "share",
+		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
+		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
+		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
+	}
 )
 
 type testCmd struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: add subDir in storage class parameters, e.g.
```yaml
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: smb
provisioner: smb.csi.k8s.io
parameters:
  source: "//smb-server.default.svc.cluster.local/share"
  subDir: "existingSubDirectoryName"  # optional
  csi.storage.k8s.io/node-stage-secret-name: "smbcreds"
  csi.storage.k8s.io/node-stage-secret-namespace: "default"
volumeBindingMode: Immediate
mountOptions:
  - dir_mode=0777
  - file_mode=0777
  - uid=1001
  - gid=1001
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #398

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
feat: add subDir in storage class parameters
```
