### PR TITLE
Tweak make rules to make cloudbuild work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,12 @@ update:
 	hack/update-dependencies.sh
 	hack/verify-update.sh
 
+# There seems to be some shell quoting problem with cloudbuild.yaml, and trying
+# to pass multiple make targets appears as a single quoted string. See
+# cloudbuild.yaml for how this is used.
+.PHONY: cloudbuild
+cloudbuild: container-all push-manifest push-latest
+
 .PHONY: verify
 verify: unit-test
 	hack/verify-all.sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
     # set the home to /root explicitly to if using docker buildx
     - HOME=/root
     args:
-      - container-all push-manifest push-latest
+      - cloudbuild
 
 substitutions:
   _STAGING_PROJECT: 'k8s-staging-cloud-provider-gcp'


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Cloudbuild has been failing ([testgrid](https://k8s-testgrid.appspot.com/sig-storage-image-build#post-csi-driver-smb-push-images)). I think this should fix it.
**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A ] includes documentation
- [ N/A] adds unit tests
- [ N/A ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
