### PR TITLE
fix: CVE issues in image build

### DIFF
--- a/pkg/smbplugin/Dockerfile
+++ b/pkg/smbplugin/Dockerfile
@@ -17,7 +17,7 @@ FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 RUN apt update && apt-mark unhold libcap2
 RUN clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs
 # install updated packages to fix CVE issues
-RUN clean-install libgmp10 bsdutils libssl1.1 openssl
+RUN clean-install libgmp10 bsdutils libssl1.1 openssl libc6 libc-bin libsystemd0
 
 LABEL maintainers="andyzhangx"
 LABEL description="SMB CSI Driver"

--- a/pkg/smbplugin/Windows.Dockerfile
+++ b/pkg/smbplugin/Windows.Dockerfile
@@ -6,7 +6,8 @@ FROM mcr.microsoft.com/windows/nanoserver:${OSVERSION}
 LABEL description="CSI SMB plugin"
 
 ARG ARCH=amd64
-COPY ./_output/${ARCH}/smbplugin.exe /smbplugin.exe
+ARG binary=./_output/${ARCH}/smbplugin.exe
+COPY ${binary} /smbplugin.exe
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 USER ContainerAdministrator
 ENTRYPOINT ["/smbplugin.exe"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: CVE issues in image build

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

```
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
|   LIBRARY   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION  |                 TITLE                 |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libc-bin    | CVE-2021-33574   | CRITICAL | 2.31-13+deb11u2   | 2.31-13+deb11u3 | glibc: mq_notify does                 |
|             |                  |          |                   |                 | not handle separately                 |
|             |                  |          |                   |                 | allocated thread attributes           |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-33574 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-23218   |          |                   |                 | glibc: Stack-based buffer overflow    |
|             |                  |          |                   |                 | in svcunix_create via long pathnames  |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23218 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-23219   |          |                   |                 | glibc: Stack-based buffer             |
|             |                  |          |                   |                 | overflow in sunrpc clnt_create        |
|             |                  |          |                   |                 | via a long pathname                   |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23219 |
+             +------------------+----------+                   +                 +---------------------------------------+
|             | CVE-2021-43396   | HIGH     |                   |                 | glibc: conversion from                |
|             |                  |          |                   |                 | ISO-2022-JP-3 with iconv may          |
|             |                  |          |                   |                 | emit spurious NUL character on...     |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-43396 |
+-------------+------------------+----------+                   +                 +---------------------------------------+
| libc6       | CVE-2021-33574   | CRITICAL |                   |                 | glibc: mq_notify does                 |
|             |                  |          |                   |                 | not handle separately                 |
|             |                  |          |                   |                 | allocated thread attributes           |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-33574 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-23218   |          |                   |                 | glibc: Stack-based buffer overflow    |
|             |                  |          |                   |                 | in svcunix_create via long pathnames  |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23218 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-23219   |          |                   |                 | glibc: Stack-based buffer             |
|             |                  |          |                   |                 | overflow in sunrpc clnt_create        |
|             |                  |          |                   |                 | via a long pathname                   |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23219 |
+             +------------------+----------+                   +                 +---------------------------------------+
|             | CVE-2021-43396   | HIGH     |                   |                 | glibc: conversion from                |
|             |                  |          |                   |                 | ISO-2022-JP-3 with iconv may          |
|             |                  |          |                   |                 | emit spurious NUL character on...     |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-43396 |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libsystemd0 | CVE-2021-3997    | MEDIUM   | 247.3-6           | 247.3-7         | systemd: Uncontrolled recursion in    |
|             |                  |          |                   |                 | systemd-tmpfiles when removing files  |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-3997  |
+-------------+                  +          +                   +                 +                                       +
| libudev1    |                  |          |                   |                 |                                       |
|             |                  |          |                   |                 |                                       |
|             |                  |          |                   |                 |                                       |
+-------------+                  +          +                   +                 +                                       +
| udev        |                  |          |                   |                 |                                       |
|             |                  |          |                   |                 |                                       |
|             |                  |          |                   |                 |                                       |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
```

**Release note**:
```
fix: CVE issues in image build
```
