### PR TITLE
fix: add default krb5 cc path

### DIFF
--- a/cmd/smbplugin/Dockerfile
+++ b/cmd/smbplugin/Dockerfile
@@ -22,4 +22,6 @@ ARG ARCH=amd64
 ARG binary=./_output/${ARCH}/smbplugin
 COPY ${binary} /smbplugin
 
+RUN echo "[libdefaults]\n    default_ccache_name = FILE:/var/lib/kubelet/kerberos/krb5cc_%{uid}\n" > /etc/krb5.conf
+
 ENTRYPOINT ["/smbplugin"]


### PR DESCRIPTION
Upon running master branch the following error was showing:

        May 11 10:19:42 worker-02 cifs.upcall: get_existing_cc: default ccache is FILE:/tmp/krb5cc_0

Checked on the host and the configuration was appropriate, mounting a cifs share did work approrpiately.

This error was showing specifically inside the smb container, so adding the configuration for the default krb5 cc path as expected by this sci.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Added default krb5.conf to the Dockerfile in `cmd/smbplugin/Dockerfile` with content:
```
[libdefaults]
	default_ccache_name = FILE:/var/lib/kubelet/kerberos/krb5cc_%{uid}
```

**Which issue(s) this PR fixes**: #612
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
Added default krb5.conf to look up krb5cc in /var/lib/kubelet/kerberos
```
