### PR TITLE
Cleaning kerberos cache files on unstage phase

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -43,16 +43,17 @@ kubectl create secret generic smbcreds --from-literal username=USERNAME --from-l
  - Kerberos support should be set up and cifs-utils must be installed on every node.
  - The directory /var/lib/kubelet/kerberos/ needs to exist, and it will hold kerberos credential cache files for various users.
  - This directory is shared between the host and the smb container.
- - The admin is responsible for cleaning up the directory on each node as they deem appropriate. It's important to note that unmounting doesn't delete the cache file.
+ - The kerberos cache files are created for each volume and cleaned up during UnstageVolume phase
  - Each node should know to look up in that directory, here's example script for that, expected to be run on node provision:
 ```console
 mkdir -p /etc/krb5.conf.d/
 echo "[libdefaults]
 default_ccache_name = FILE:/var/lib/kubelet/kerberos/krb5cc_%{uid}" > /etc/krb5.conf.d/ccache.conf
    ```
- - Mount flags should include **sec=krb5,cruid=1000**
+ - Mount flags should include **sec=krb5,uid=1000,cruid=1000**
    - sec=krb5 enables using credential cache
    - cruid=1000 provides information for what user credential cache will be looked up. This should match the secret entry.
+   - uid=1000 is the owner of mounted files. This doesn't have to be the same as cruid.
 
 #### Pass kerberos ticket in kubernetes secret 
 To pass a ticket through secret, it needs to be acquired. Here's example how it can be done:

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -692,6 +692,29 @@ func TestCheckGidPresentInMountFlags(t *testing.T) {
 	}
 }
 
+func TestVolumeKerberosCacheName(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "s", // short name
+		},
+		{
+			name: "Volume Handle##unique suffix",
+		},
+		{
+			name: "Volume With Spaces and Slashes // and symbols that produce /+ after base64 ???????~~~~~~~~",
+		},
+	}
+
+	for _, test := range tests {
+		fileName := volumeKerberosCacheName(test.name)
+		if strings.Contains(fileName, "/") || strings.Contains(fileName, "+") {
+			t.Errorf("[%s]: Expected result should not contain / or +, Actual result: %s", test.name, fileName)
+		}
+	}
+}
+
 func TestHasKerberosMountOption(t *testing.T) {
 	tests := []struct {
 		desc       string


### PR DESCRIPTION
Extending initial support for kerberos-based ticket mounting. Previously, cache has been written directly to the expected file - krb5cc_*. With this change, cache is written to the base64(volumeID) file, and then symlink krb5cc_* created pointing to the file with the cache. During unstage phase only volumeID and mount path is available, and having volumeID it's possible to do the cleanup with simple traversing directory containing the caches.


**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adding kerberos cache files cleanup, that will improve use of driver, and remove onus from end users to actually clean those cache files.

**Which issue(s) this PR fixes**:

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
Kerberos cache files now auto-removed once volume is unstaged/removed.
```
