### PR TITLE
Version 1.1.2 is latest

### DIFF
--- a/deploy/example/windows/csi-proxy.yaml
+++ b/deploy/example/windows/csi-proxy.yaml
@@ -24,4 +24,4 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-proxy
-          image: ghcr.io/kubernetes-sigs/sig-windows/csi-proxy:v1.0.2
+          image: ghcr.io/kubernetes-sigs/sig-windows/csi-proxy:v1.1.2


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/kind deprecation
/kind feature

**What this PR does / why we need it**:

Fix to upstream version

**Which issue(s) this PR fixes**:

All bugs fixed between 1.0.2 and 1.1.2 of csi proxy.

        chore: Maintenance 🔧
        docs: Documentation 📘

**Release note**:
```
Image for csi-proxy updated to 1.1.2
```
