### PR TITLE
test: use env var for smb server configuration

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -61,6 +61,10 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			Volumes: []testsuites.VolumeDetails{
 				{
 					ClaimSize: "10Gi",
+					MountOptions: []string{
+						"dir_mode=0777",
+						"file_mode=0777",
+					},
 					VolumeMount: testsuites.VolumeMountDetails{
 						NameGenerate:      "test-volume-",
 						MountPathGenerate: "/mnt/test-",
@@ -203,6 +207,10 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			Volumes: []testsuites.VolumeDetails{
 				{
 					ClaimSize: "10Gi",
+					MountOptions: []string{
+						"dir_mode=0777",
+						"file_mode=0777",
+					},
 					VolumeMount: testsuites.VolumeMountDetails{
 						NameGenerate:      "test-volume-",
 						MountPathGenerate: "/mnt/test-",

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -38,59 +38,65 @@ import (
 )
 
 const (
-	kubeconfigEnvVar  = "KUBECONFIG"
-	reportDirEnv      = "ARTIFACTS"
-	testWindowsEnvVar = "TEST_WINDOWS"
-	defaultReportDir  = "test/e2e"
+	kubeconfigEnvVar             = "KUBECONFIG"
+	reportDirEnv                 = "ARTIFACTS"
+	testWindowsEnvVar            = "TEST_WINDOWS"
+	defaultReportDir             = "test/e2e"
+	testSmbSourceEnvVar          = "TEST_SMB_SOURCE"
+	testSmbSecretNameEnvVar      = "TEST_SMB_SECRET_NAME"
+	testSmbSecretNamespaceEnvVar = "TEST_SMB_SECRET_NAMESPACE"
+	defaultSmbSource             = "//smb-server.default.svc.cluster.local/share"
+	defaultSmbSecretName         = "smbcreds"
+	defaultSmbSecretNamespace    = "default"
 )
 
 var (
 	smbDriver                     *smb.Driver
 	isWindowsCluster              = os.Getenv(testWindowsEnvVar) != ""
 	defaultStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
-		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 	}
 	subDirStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
 		"subDir": "subDirectory-${pvc.metadata.name}",
-		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 	}
 	retainStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
-		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 		"onDelete": "retain",
 	}
 	archiveStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
-		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 		"onDelete": "archive",
 	}
 	archiveSubDirStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
 		"subDir": "${pvc.metadata.namespace}/${pvc.metadata.name}",
-		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 		"onDelete": "archive",
 	}
 	noProvisionerSecretStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
-		"csi.storage.k8s.io/node-stage-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace": "default",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
+		"csi.storage.k8s.io/node-stage-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 	}
 )
 
@@ -110,6 +116,11 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 	handleFlags()
 	framework.AfterReadingAllFlags(&framework.TestContext)
+
+	kubeconfig := os.Getenv(kubeconfigEnvVar)
+	options := smb.DriverOptions{
+		DriverName: smb.DefaultDriverName,
+	}
 
 	if testutil.IsRunningInProw() {
 		// Install SMB provisioner on cluster
@@ -137,17 +148,16 @@ var _ = ginkgo.BeforeSuite(func() {
 		execTestCmd([]testCmd{installSMBProvisioner, e2eBootstrap, createMetricsSVC})
 
 		nodeid := os.Getenv("nodeid")
-		kubeconfig := os.Getenv(kubeconfigEnvVar)
-		options := smb.DriverOptions{
+		options = smb.DriverOptions{
 			NodeID:               nodeid,
 			DriverName:           smb.DefaultDriverName,
 			EnableGetVolumeStats: false,
 		}
-		smbDriver = smb.NewDriver(&options)
-		go func() {
-			smbDriver.Run(fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()), kubeconfig, false)
-		}()
 	}
+	smbDriver = smb.NewDriver(&options)
+	go func() {
+		smbDriver.Run(fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()), kubeconfig, false)
+	}()
 
 	if isWindowsCluster {
 		err := os.Chdir("../..")
@@ -269,4 +279,13 @@ func skipIfTestingInWindowsCluster() {
 	if isWindowsCluster {
 		ginkgo.Skip("test case not supported by Windows clusters")
 	}
+}
+
+// getSmbTestEnvVarValue gets the smbTestEnvValue from env var if the var does not set use the defaultVarValue
+func getSmbTestEnvVarValue(envVarName string, defaultVarValue string) (smbTestEnvValue string) {
+	smbTestEnvValue = os.Getenv(envVarName)
+	if smbTestEnvValue == "" {
+		smbTestEnvValue = defaultVarValue
+	}
+	return
 }

--- a/test/utils/check_driver_pods_restart.sh
+++ b/test/utils/check_driver_pods_restart.sh
@@ -16,8 +16,11 @@
 
 set -e
 
+# Get the value of the environment variable or set a default value if it's empty
+CSI_DRIVER_INSTALLED_NAMESPACE="${CSI_DRIVER_INSTALLED_NAMESPACE:-kube-system}"
+
 echo "check the driver pods if restarts ..."
-restarts=$(kubectl get pods -n kube-system | grep smb | awk '{print $4}')
+restarts=$(kubectl get pods -n "${CSI_DRIVER_INSTALLED_NAMESPACE}" | grep smb | awk '{print $4}')
 for num in $restarts
 do
     if [ "$num" -ne "0" ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
- Fixed run the e2e test locally the smbDriver nil pointer issue
- Use env var for smb server configuration to make e2e test execute in different test clusters more flexibility.
- Use obvious mountOption in case to make e2e test could be executed in some different smb server configurations

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
