### PR TITLE
fix: Remove stale archived volume copy before Rename

### DIFF
--- a/pkg/smb/controllerserver.go
+++ b/pkg/smb/controllerserver.go
@@ -189,8 +189,11 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 				}
 			}
 
-			// archive subdirectory under base-dir
+			// archive subdirectory under base-dir. Remove stale archived copy if exists.
 			klog.V(2).Infof("archiving subdirectory %s --> %s", internalVolumePath, archivedInternalVolumePath)
+			if err = os.RemoveAll(archivedInternalVolumePath); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to delete archived subdirectory %s: %v", archivedInternalVolumePath, err.Error())
+			}
 			if err = os.Rename(internalVolumePath, archivedInternalVolumePath); err != nil {
 				return nil, status.Errorf(codes.Internal, "archive subdirectory(%s, %s) failed with %v", internalVolumePath, archivedInternalVolumePath, err.Error())
 			}


### PR DESCRIPTION
The user might put non-unique spec for subdir:
```
subDir: ${pvc.metadata.namespace}/${pvc.metadata.name}
```
Then, `os.Rename(internalVolumePath, archivedInternalVolumePath)` can fail becaue the destination (`archivedInternalVolumePath`) already exists. It's safer to remove it before `os.Rename()`.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Sensitive user data may leak across Pod create/delete in spite of reclaim policy "Delete". See https://github.com/kubernetes-csi/csi-driver-smb/security/advisories/GHSA-rmg6-rh96-c9wx for details.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-csi/csi-driver-smb/security/advisories/GHSA-rmg6-rh96-c9wx

**Special notes for your reviewer**:


**Release note**:
```
Previously, in archiveOnDelete mode, it was possible that PV cannot not archived because previously archived volume keeps the same name. Now, such a stale archived item is deleted before archiving new one.
```
