### PR TITLE
fix: Remove excessive recursive variable expansions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ CMDS=smbplugin
 PKG = github.com/kubernetes-csi/csi-driver-smb
 GINKGO_FLAGS = -ginkgo.v -ginkgo.timeout=2h
 GO111MODULE = on
-GOPATH ?= $(shell go env GOPATH)
+ifndef GOPATH
+GOPATH := $(shell go env GOPATH)
+endif
 GOBIN ?= $(GOPATH)/bin
 DOCKER_CLI_EXPERIMENTAL = enabled
 IMAGENAME ?= smb-csi
@@ -24,9 +26,9 @@ export GOPATH GOBIN GO111MODULE DOCKER_CLI_EXPERIMENTAL
 
 include release-tools/build.make
 
-GIT_COMMIT ?= $(shell git rev-parse HEAD)
+GIT_COMMIT := $(shell git rev-parse HEAD)
 REGISTRY ?= andyzhangx
-REGISTRY_NAME = $(shell echo $(REGISTRY) | sed "s/.azurecr.io//g")
+REGISTRY_NAME := $(shell echo $(REGISTRY) | sed "s/.azurecr.io//g")
 IMAGE_VERSION ?= v1.15.0
 VERSION ?= latest
 # Use a custom version for E2E tests if we are testing in CI
@@ -37,7 +39,9 @@ endif
 endif
 IMAGE_TAG = $(REGISTRY)/$(IMAGENAME):$(IMAGE_VERSION)
 IMAGE_TAG_LATEST = $(REGISTRY)/$(IMAGENAME):latest
-BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+ifndef BUILD_DATE
+BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+endif
 LDFLAGS = -X ${PKG}/pkg/smb.driverVersion=${IMAGE_VERSION} -X ${PKG}/pkg/smb.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/smb.buildDate=${BUILD_DATE}
 EXT_LDFLAGS = -s -w -extldflags "-static"
 E2E_HELM_OPTIONS ?= --set image.smb.repository=$(REGISTRY)/$(IMAGENAME) --set image.smb.tag=$(IMAGE_VERSION)


### PR DESCRIPTION
Modern GNU make (version >= 4.4) has backward-incompatible feature:

> * WARNING: Backward-incompatibility!
>  Previously makefile variables marked as export were not exported to commands
>  started by the $(shell ...) function.  Now, all exported variables are
>  exported to $(shell ...).  If this leads to recursion during expansion, then
>  for backward-compatibility the value from the original environment is used.

This makes any invocation of `make` command very costly. Compare the performance of make 4.3 vs. 4.4:
```
$ time ~/Sources/make-4.3/make smb ARCH=$(go env GOARCH)
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=v1.15.0 -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=f5ced814f628ddee2c9f3e6af505c5a6123e50f4 -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=2024-05-15T00:00:09Z -s -w -extldflags "-static"" -mod vendor -o _output/amd64/smbplugin ./cmd/smbplugin

real	0m38.504s
user	3m50.580s
sys	0m23.502s

$ time ~/Sources/make-4.4/make smb ARCH=$(go env GOARCH)
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=v1.15.0 -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=f5ced814f628ddee2c9f3e6af505c5a6123e50f4 -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=2024-05-15T00:04:04Z -s -w -extldflags "-static"" -mod vendor -o _output/amd64/smbplugin ./cmd/smbplugin

real	16m59.851s
user	13m16.490s
sys	13m46.418s
```

The same variables are evaluated again and again millions times:
```
$ rpm -qf /usr/bin/make
make-4.4.1-6.fc40.x86_64

$ /usr/bin/make -d smb ARCH=$(go env GOARCH) 2>&1 |grep "not recursively expanding.*to export to shell function" |wc -l
2171342
```

The patch doesn't change user-visible behavior of Makefile, but makes `make` command as performant as it used to be in case of make 4.3.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Modern `make` (>= 4.4) builds csi driver extremely slowly.

**Release note**:
```
none
```
