### PR TITLE
fix: delete volume error in archive deletion mode

### DIFF
--- a/pkg/smb/controllerserver.go
+++ b/pkg/smb/controllerserver.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 )
 
 const (
@@ -147,6 +148,11 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 
+	if acquired := d.volumeLocks.TryAcquire(volumeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, volumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer d.volumeLocks.Release(volumeID)
+
 	var volCap *csi.VolumeCapability
 	secrets := req.GetSecrets()
 	mountOptions := getMountOptions(secrets)
@@ -167,6 +173,16 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 
 	if len(req.GetSecrets()) > 0 && !strings.EqualFold(smbVol.onDelete, retain) {
 		klog.V(2).Infof("begin to delete or archive subdirectory since secret is provided")
+		// check whether volumeID is in the cache
+		cache, err := d.volDeletionCache.Get(volumeID, azcache.CacheReadTypeDefault)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, err.Error())
+		}
+		if cache != nil {
+			klog.V(2).Infof("DeleteVolume: volume %s is already deleted", volumeID)
+			return &csi.DeleteVolumeResponse{}, nil
+		}
+
 		// mount smb base share so we can delete or archive the subdirectory
 		if err = d.internalMount(ctx, smbVol, volCap, secrets); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to mount smb server: %v", err.Error())
@@ -211,6 +227,7 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		klog.V(2).Infof("DeleteVolume(%s) does not delete subdirectory", volumeID)
 	}
 
+	d.volDeletionCache.Set(volumeID, "")
 	return &csi.DeleteVolumeResponse{}, nil
 }
 

--- a/pkg/smb/smb.go
+++ b/pkg/smb/smb.go
@@ -82,6 +82,8 @@ type Driver struct {
 	enableGetVolumeStats bool
 	// a timed cache storing volume stats <volumeID, volumeStats>
 	volStatsCache azcache.Resource
+	// a timed cache storing volume deletion records <volumeID, "">
+	volDeletionCache azcache.Resource
 	// this only applies to Windows node
 	removeSMBMappingDuringUnmount bool
 	krb5CacheDirectory            string
@@ -118,6 +120,9 @@ func NewDriver(options *DriverOptions) *Driver {
 	var err error
 	getter := func(key string) (interface{}, error) { return nil, nil }
 	if driver.volStatsCache, err = azcache.NewTimedCache(time.Duration(options.VolStatsCacheExpireInMinutes)*time.Minute, getter, false); err != nil {
+		klog.Fatalf("%v", err)
+	}
+	if driver.volDeletionCache, err = azcache.NewTimedCache(time.Minute, getter, false); err != nil {
 		klog.Fatalf("%v", err)
 	}
 	return &driver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: delete volume error in archive deletion mode 

when `onDelete: archive`, there could be delete volume error with error msg `rename xxx: no such file or directory` since there is a bug in csi-provisioner that DeleteVolume may be performed twice, this PR adds a 1 min cache and lock to workaround this issue.



```
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.334699       1 utils.go:76] GRPC call: /csi.v1.Controller/DeleteVolume
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.334752       1 utils.go:77] GRPC request: {"secrets":"***stripped***","volume_id":"135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive"}
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.334843       1 controllerserver.go:154] DeleteVolume: found mountOptions(dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks) for volume(135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive)
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.334864       1 controllerserver.go:169] begin to delete or archive subdirectory since secret is provided
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.334876       1 controllerserver.go:292] internally mounting //135.236.234.180/share at /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.335104       1 nodeserver.go:209] NodeStageVolume: targetPath(/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2) volumeID(135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive) context(map[source://135.236.234.180/share]) mountflags([dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks]) mountOptions([dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks])
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.335322       1 mount_linux.go:218] Mounting cmd (mount) with arguments (-t cifs -o dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks,<masked> //135.236.234.180/share /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2)
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.373268       1 nodeserver.go:241] volume(135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive) mount "//135.236.234.180/share" on "/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2" succeeded
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.374874       1 controllerserver.go:186] DeleteVolume: subdirectory(smb-4792/pvc-ckk2v) contains '/', make sure the parent directory(/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792) exists
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.381550       1 controllerserver.go:193] archiving subdirectory /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/smb-4792/pvc-ckk2v --> /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792/pvc-ckk2v
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.381577       1 controllerserver.go:195] removing archived subdirectory at /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792/pvc-ckk2v
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.383991       1 controllerserver.go:199] removed archived subdirectory at /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792/pvc-ckk2v
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.391986       1 controllerserver.go:310] internally unmounting /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.392012       1 nodeserver.go:264] NodeUnstageVolume: CleanupMountPoint on /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2 with volume 135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.393671       1 mount_helper_common.go:93] unmounting "/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2" (corruptedMount: false, mounterCanSkipMountPointChecks: true)
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.393698       1 mount_linux.go:360] Unmounting /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.399036       1 mount_helper_common.go:150] Deleting path "/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2"
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.399168       1 nodeserver.go:273] NodeUnstageVolume: unmount volume 135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive on /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2 successfully
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.399192       1 utils.go:83] GRPC response: {}
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.427703       1 utils.go:76] GRPC call: /csi.v1.Controller/DeleteVolume
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.427736       1 utils.go:77] GRPC request: {"secrets":"***stripped***","volume_id":"135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive"}
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.427840       1 controllerserver.go:154] DeleteVolume: found mountOptions(dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks) for volume(135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive)
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.427855       1 controllerserver.go:169] begin to delete or archive subdirectory since secret is provided
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.427871       1 controllerserver.go:292] internally mounting //135.236.234.180/share at /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.428098       1 nodeserver.go:209] NodeStageVolume: targetPath(/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2) volumeID(135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive) context(map[source://135.236.234.180/share]) mountflags([dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks]) mountOptions([dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks])
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.428345       1 mount_linux.go:218] Mounting cmd (mount) with arguments (-t cifs -o dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks,<masked> //135.236.234.180/share /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2)
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.454514       1 nodeserver.go:241] volume(135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive) mount "//135.236.234.180/share" on "/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2" succeeded
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.454559       1 controllerserver.go:186] DeleteVolume: subdirectory(smb-4792/pvc-ckk2v) contains '/', make sure the parent directory(/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792) exists
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.456730       1 controllerserver.go:193] archiving subdirectory /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/smb-4792/pvc-ckk2v --> /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792/pvc-ckk2v
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.456753       1 controllerserver.go:195] removing archived subdirectory at /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792/pvc-ckk2v
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.470770       1 controllerserver.go:199] removed archived subdirectory at /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792/pvc-ckk2v
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.476121       1 controllerserver.go:310] internally unmounting /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.476146       1 nodeserver.go:264] NodeUnstageVolume: CleanupMountPoint on /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2 with volume 135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.476172       1 mount_helper_common.go:93] unmounting "/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2" (corruptedMount: false, mounterCanSkipMountPointChecks: true)
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.476185       1 mount_linux.go:360] Unmounting /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.484264       1 mount_helper_common.go:150] Deleting path "/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2"
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] I0829 08:02:15.484631       1 nodeserver.go:273] NodeUnstageVolume: unmount volume 135.236.234.180/share#smb-4792/pvc-ckk2v#pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2#archive on /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2 successfully
[pod/csi-smb-controller-79db546bb6-rn2bd/smb] E0829 08:02:15.484657       1 utils.go:81] GRPC error: rpc error: code = Internal desc = archive subdirectory(/tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/smb-4792/pvc-ckk2v, /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792/pvc-ckk2v) failed with rename /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/smb-4792/pvc-ckk2v /tmp/pvc-b1130ed7-05eb-4a93-99ff-92b80fc82ac2/archived-smb-4792/pvc-ckk2v: no such file or directory
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: delete volume error in archive deletion mode
```
