### PR TITLE
fix: remove parent dir in DeleteVolume

### DIFF
--- a/pkg/smb/controllerserver.go
+++ b/pkg/smb/controllerserver.go
@@ -232,7 +232,14 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 				return nil, status.Errorf(codes.Internal, "archive subdirectory(%s, %s) failed with %v", internalVolumePath, archivedInternalVolumePath, err)
 			}
 		} else {
-			klog.V(2).Infof("Removing subdirectory at %v", internalVolumePath)
+			rootDir := getRootDir(smbVol.subDir)
+			if rootDir != "" {
+				rootDir = filepath.Join(getInternalMountPath(d.workingMountDir, smbVol), rootDir)
+			} else {
+				rootDir = internalVolumePath
+			}
+
+			klog.V(2).Infof("removing subdirectory at %v on internalVolumePath %s", rootDir, internalVolumePath)
 			if err = os.RemoveAll(internalVolumePath); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to delete subdirectory: %v", err)
 			}

--- a/pkg/smb/smb.go
+++ b/pkg/smb/smb.go
@@ -263,3 +263,9 @@ func appendMountOptions(mountOptions []string, extraMountOptions map[string]stri
 	}
 	return allMountOptions
 }
+
+// getRootDir returns the root directory of the given directory
+func getRootDir(path string) string {
+	parts := strings.Split(path, "/")
+	return parts[0]
+}

--- a/pkg/smb/smb_test.go
+++ b/pkg/smb/smb_test.go
@@ -379,3 +379,44 @@ func TestAppendMountOptions(t *testing.T) {
 		}
 	}
 }
+
+func TestGetRootPath(t *testing.T) {
+	tests := []struct {
+		desc     string
+		dir      string
+		expected string
+	}{
+		{
+			desc:     "empty path",
+			dir:      "",
+			expected: "",
+		},
+		{
+			desc:     "root path",
+			dir:      "/",
+			expected: "",
+		},
+		{
+			desc:     "subdir path",
+			dir:      "/subdir",
+			expected: "",
+		},
+		{
+			desc:     "subdir path without leading slash",
+			dir:      "subdir",
+			expected: "subdir",
+		},
+		{
+			desc:     "multiple subdir path without leading slash",
+			dir:      "subdir/subdir2",
+			expected: "subdir",
+		},
+	}
+
+	for _, test := range tests {
+		result := getRootDir(test.dir)
+		if result != test.expected {
+			t.Errorf("Unexpected result: %s, expected: %s", result, test.expected)
+		}
+	}
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -63,7 +63,7 @@ var (
 	}
 	subDirStorageClassParameters = map[string]string{
 		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
-		"subDir": "subDirectory-${pvc.metadata.name}",
+		"subDir": "${pvc.metadata.namespace}/${pvc.metadata.name}",
 		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
 		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: remove parent dir in DeleteVolume

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
<details>

```
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.821458       1 utils.go:76] GRPC call: /csi.v1.Controller/DeleteVolume
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.821498       1 utils.go:77] GRPC request: {"secrets":"***stripped***","volume_id":"smb-server.default.svc.cluster.local/share#smb-6446/pvc-t8w7t#pvc-537d3618-595b-4796-81f6-794effd6d54e#"}
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.821684       1 controllerserver.go:169] DeleteVolume: found mountOptions(dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks) for volume(smb-server.default.svc.cluster.local/share#smb-6446/pvc-t8w7t#pvc-537d3618-595b-4796-81f6-794effd6d54e#)
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.821757       1 controllerserver.go:189] begin to delete or archive subdirectory since secret is provided
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.821931       1 controllerserver.go:330] internally mounting //smb-server.default.svc.cluster.local/share at /tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.822328       1 nodeserver.go:209] NodeStageVolume: targetPath(/tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e) volumeID(smb-server.default.svc.cluster.local/share#smb-6446/pvc-t8w7t#pvc-537d3618-595b-4796-81f6-794effd6d54e#) context(map[source://smb-server.default.svc.cluster.local/share]) mountflags([dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks file_mode=0777]) mountOptions([dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks file_mode=0777])
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.822750       1 mount_linux.go:218] Mounting cmd (mount) with arguments (-t cifs -o dir_mode=0777,file_mode=0777,uid=0,gid=0,mfsymlinks,file_mode=0777,<masked> //smb-server.default.svc.cluster.local/share /tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e)
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.867097       1 nodeserver.go:241] volume(smb-server.default.svc.cluster.local/share#smb-6446/pvc-t8w7t#pvc-537d3618-595b-4796-81f6-794effd6d54e#) mount "//smb-server.default.svc.cluster.local/share" on "/tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e" succeeded
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.867414       1 controllerserver.go:242] removing subdirectory at /tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e/smb-6446 on internalVolumePath /tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e/smb-6446/pvc-t8w7t
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.873482       1 controllerserver.go:348] internally unmounting /tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.873510       1 nodeserver.go:264] NodeUnstageVolume: CleanupMountPoint on /tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e with volume smb-server.default.svc.cluster.local/share#smb-6446/pvc-t8w7t#pvc-537d3618-595b-4796-81f6-794effd6d54e#
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.873578       1 mount_helper_common.go:93] unmounting "/tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e" (corruptedMount: false, mounterCanSkipMountPointChecks: true)
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.873597       1 mount_linux.go:360] Unmounting /tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.879301       1 mount_helper_common.go:150] Deleting path "/tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e"
[pod/csi-smb-controller-794dfcb554-sd6gc/smb] I0915 05:07:46.879522       1 nodeserver.go:273] NodeUnstageVolume: unmount volume smb-server.default.svc.cluster.local/share#smb-6446/pvc-t8w7t#pvc-537d3618-595b-4796-81f6-794effd6d54e# on /tmp/pvc-537d3618-595b-4796-81f6-794effd6d54e successfully
```

</details>

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: remove parent dir in DeleteVolume
```
