### PR TITLE
test: add read-only subdir e2e test

### DIFF
--- a/test/e2e/testsuites/dynamically_provisioned_delete_pod_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_delete_pod_tester.go
@@ -34,6 +34,7 @@ type DynamicallyProvisionedDeletePodTest struct {
 	CSIDriver              driver.DynamicPVTestDriver
 	Pod                    PodDetails
 	PodCheck               *PodExecCheck
+	SkipAfterRestartCheck  bool
 	StorageClassParameters map[string]string
 }
 
@@ -67,7 +68,7 @@ func (t *DynamicallyProvisionedDeletePodTest) Run(ctx context.Context, client cl
 	ginkgo.By("checking again that the pod is running")
 	tDeployment.WaitForPodReady(ctx)
 
-	if t.PodCheck != nil {
+	if t.PodCheck != nil && !t.SkipAfterRestartCheck {
 		ginkgo.By("sleep 5s and then check pod exec after pod restart again")
 		time.Sleep(5 * time.Second)
 		// pod will be restarted so expect to see 2 instances of string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
-  Add test coverage to avoid regression of https://github.com/kubernetes-csi/csi-driver-smb/issues/834 .

```console
$ go test -v -timeout=0 ./test/e2e -ginkgo.v -ginkgo.timeout=1h
...
2024/11/29 15:13:47 ===================================================
[AfterSuite] PASSED [6.902 seconds]
------------------------------

Ran 13 of 14 Specs in 398.356 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 1 Skipped
You're using deprecated Ginkgo functionality:
=============================================
  Support for custom reporters has been removed in V2.  Please read the documentation linked to below for Ginkgo's new behavior and for a migration path:
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#removed-custom-reporters

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.17.1

--- PASS: TestE2E (398.36s)
PASS
ok      github.com/kubernetes-csi/csi-driver-smb/test/e2e       399.271s
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
