### PR TITLE
fix: SmbGlobalMapping leak due to wrong driverGlobalMountPath and silent skip on error on Windows

### DIFF
--- a/pkg/mounter/safe_mounter_host_process_windows.go
+++ b/pkg/mounter/safe_mounter_host_process_windows.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kubernetes-csi/csi-driver-smb/pkg/os/smb"
 )
 
-var driverGlobalMountPath = "C:\\var\\lib\\kubelet\\plugins\\kubernetes.io\\csi\\file.csi.azure.com"
+var driverGlobalMountPath = "C:\\var\\lib\\kubelet\\plugins\\kubernetes.io\\csi\\smb.csi.k8s.io"
 
 var _ CSIProxyMounter = &winMounter{}
 
@@ -149,7 +149,10 @@ func (mounter *winMounter) SMBUnmount(target, _ string) error {
 				klog.V(2).Infof("skip unmount as there are other SMB mounts on the same remote server %s", remoteServer)
 			}
 		} else {
-			klog.Errorf("CheckForDuplicateSMBMounts(%s, %s) failed with %v", target, remoteServer, err)
+			klog.Warningf("CheckForDuplicateSMBMounts(%s, %s) failed with %v, removing mapping as fallback", target, remoteServer, err)
+			if err := smb.RemoveSmbGlobalMapping(remoteServer); err != nil {
+				klog.Errorf("RemoveSmbGlobalMapping(%s) failed with %v", target, err)
+			}
 		}
 	} else {
 		klog.Errorf("GetRemoteServerFromTarget(%s) failed with %v", target, err)


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`driverGlobalMountPath` in the HostProcess mounter (`winMounter`) was hardcoded to `file.csi.azure.com` instead of `smb.csi.k8s.io`. This caused `CheckForDuplicateSMBMounts` to always fail with a directory-not-found error, and the error path silently skipped `RemoveSmbGlobalMapping`, leaking mappings on every unmount.

Also fix the error fallback: when `CheckForDuplicateSMBMounts` fails, call `RemoveSmbGlobalMapping` instead of silently skipping it.

## Which issue(s) this PR fixes

Fixes https://github.com/kubernetes-csi/csi-driver-smb/issues/1035

## Requirements
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

## Special notes for your reviewer

The `csiProxyMounter` code path has the correct `driverGlobalMountPath` (`smb.csi.k8s.io`) and already calls `RemoveSmbGlobalMapping` on error. This fix aligns the `winMounter` (HostProcess) code path with the `csiProxyMounter` behavior.

## Release note
```
Fix SmbGlobalMapping leak in Windows HostProcess mounter: correct driverGlobalMountPath from file.csi.azure.com to smb.csi.k8s.io and remove mapping on CheckForDuplicateSMBMounts error
```