### PR TITLE
fix: correct driverGlobalMountPath from file.csi.azure.com to smb.csi.k8s.io on Windows

### DIFF
--- a/pkg/mounter/safe_mounter_host_process_windows.go
+++ b/pkg/mounter/safe_mounter_host_process_windows.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kubernetes-csi/csi-driver-smb/pkg/os/smb"
 )
 
-var driverGlobalMountPath = "C:\\var\\lib\\kubelet\\plugins\\kubernetes.io\\csi\\file.csi.azure.com"
+var driverGlobalMountPath = "C:\\var\\lib\\kubelet\\plugins\\kubernetes.io\\csi\\smb.csi.k8s.io"
 
 var _ CSIProxyMounter = &winMounter{}
 


### PR DESCRIPTION
## What this PR does

Fixes the hardcoded `driverGlobalMountPath` from `file.csi.azure.com` to `smb.csi.k8s.io`.

This is a single-line fix extracted from #1036 per [review feedback](https://github.com/kubernetes-csi/csi-driver-smb/pull/1036/files#r2922021375) — only the L38 path correction, without the SMBUnmount error-handling changes.

## Problem

`driverGlobalMountPath` was hardcoded to `C:\var\lib\kubelet\plugins\kubernetes.io\csi\file.csi.azure.com` instead of `C:\var\lib\kubelet\plugins\kubernetes.io\csi\smb.csi.k8s.io`. This caused `CheckForDuplicateSMBMounts` to always fail with a directory-not-found error, leading to `SmbGlobalMapping` leaks on every unmount.

## Changes

- `pkg/mounter/safe_mounter_host_process_windows.go` L36: `file.csi.azure.com` → `smb.csi.k8s.io`

Fixes #1035