### PR TITLE
fix: allow multiple CIFS krb5 mounts with the same CRUID

### DIFF
--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -616,7 +616,7 @@ func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID st
 
 	cruidLockKey := fmt.Sprintf("cruid-%d", credUID)
 	if acquired := d.volumeLocks.TryAcquire(cruidLockKey); !acquired {
-		return false, status.Errorf(codes.Aborted, volumeOperationAlreadyExistsFmt, cruidLockKey)
+		return false, status.Errorf(codes.Aborted, "another kerberos cache operation for CRUID %d is already in progress", credUID)
 	}
 	defer d.volumeLocks.Release(cruidLockKey)
 

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -603,10 +603,9 @@ func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID st
 	if err != nil {
 		return false, err
 	}
-
 	volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
-	volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
 
+	volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
 	if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
 		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't write kerberos cache to file %s: %v", volumeIDCacheAbsolutePath, err))
 	}
@@ -614,25 +613,63 @@ func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID st
 		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't chown kerberos cache %s to user %d: %v", volumeIDCacheAbsolutePath, credUID, err))
 	}
 
-	cruidLockKey := fmt.Sprintf("cruid-%d", credUID)
-	if acquired := d.volumeLocks.TryAcquire(cruidLockKey); !acquired {
-		return false, status.Errorf(codes.Aborted, "another kerberos cache operation for CRUID %d is already in progress", credUID)
-	}
-	defer d.volumeLocks.Release(cruidLockKey)
-
-	// Use Lstat so a dangling symlink is still detected as present — os.Stat
-	// would follow the link and report ENOENT, causing the subsequent Symlink
-	// to fail with "file exists".
-	if _, err := os.Lstat(krb5CacheFileName); os.IsNotExist(err) {
-		klog.V(2).Infof("Symlink file doesn't exist, it will be created [%s]", krb5CacheFileName)
-	} else {
-		if err := os.Remove(krb5CacheFileName); err != nil {
-			klog.Warningf("Couldn't delete the file [%s]: %v", krb5CacheFileName, err)
+	// Check if a valid symlink already exists — if so, leave it alone for concurrent mounts.
+	// Use Lstat so a dangling symlink is still detected as present.
+	shouldCreateSymlink := true
+	fileInfo, statErr := os.Lstat(krb5CacheFileName)
+	if statErr == nil {
+		if fileInfo.Mode()&os.ModeSymlink != 0 {
+			symlinkTarget, readErr := os.Readlink(krb5CacheFileName)
+			if readErr != nil {
+				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't read symlink %s: %v", krb5CacheFileName, readErr))
+			}
+			// Accept any existing symlink that points to a valid, readable cache file.
+			// This avoids racing with concurrent mounts for the same cruid but different volumes.
+			if _, targetErr := os.Stat(krb5CacheFileName); targetErr == nil {
+				klog.V(2).Infof("Valid symlink already exists [%s -> %s], leaving it alone for concurrent mount.", krb5CacheFileName, symlinkTarget)
+				shouldCreateSymlink = false
+			}
 		}
+		if shouldCreateSymlink {
+			if err := os.Remove(krb5CacheFileName); err != nil && !os.IsNotExist(err) {
+				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't remove existing kerberos cache path %s: %v", krb5CacheFileName, err))
+			}
+		}
+	} else if !os.IsNotExist(statErr) {
+		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't inspect kerberos cache path %s: %v", krb5CacheFileName, statErr))
 	}
 
-	if err := os.Symlink(volumeIDCacheAbsolutePath, krb5CacheFileName); err != nil {
-		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create symlink to a cache file %s->%s for user %d: %v", krb5CacheFileName, volumeIDCacheFileName, credUID, err))
+	if shouldCreateSymlink {
+		// Use atomic temp-symlink + rename to avoid a window where krb5CacheFileName is missing.
+		created := false
+		var tempSymlinkName string
+		for attempt := 0; attempt < 5; attempt++ {
+			tempSymlinkName = filepath.Join(filepath.Dir(krb5CacheFileName), fmt.Sprintf(".%s.tmp.%d", filepath.Base(krb5CacheFileName), time.Now().UnixNano()))
+			if err := os.Symlink(volumeIDCacheAbsolutePath, tempSymlinkName); err != nil {
+				if os.IsExist(err) {
+					klog.V(2).Infof("Temporary symlink path %s already exists, retrying.", tempSymlinkName)
+					continue
+				}
+				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create temporary symlink %s -> %s for credUID %d: %v", tempSymlinkName, volumeIDCacheAbsolutePath, credUID, err))
+			}
+			created = true
+			break
+		}
+		if !created {
+			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create temporary symlink for kerberos cache %s after retries", krb5CacheFileName))
+		}
+
+		if err := os.Rename(tempSymlinkName, krb5CacheFileName); err != nil {
+			if removeErr := os.Remove(krb5CacheFileName); removeErr != nil && !os.IsNotExist(removeErr) {
+				os.Remove(tempSymlinkName)
+				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't replace kerberos symlink %s: rename failed: %v, remove failed: %v", krb5CacheFileName, err, removeErr))
+			}
+			if retryErr := os.Rename(tempSymlinkName, krb5CacheFileName); retryErr != nil {
+				os.Remove(tempSymlinkName)
+				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't atomically update kerberos symlink %s -> %s for credUID %d: %v", krb5CacheFileName, volumeIDCacheAbsolutePath, credUID, retryErr))
+			}
+		}
+		klog.V(2).Infof("Updated kerberos symlink %s -> %s", krb5CacheFileName, volumeIDCacheAbsolutePath)
 	}
 
 	return true, nil

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -25,7 +25,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -234,7 +233,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			sensitiveMountOptions = []string{password}
 		}
 	} else {
-		var useKerberosCache, err = ensureKerberosCache(d.krb5CacheDirectory, d.krb5Prefix, volumeID, mountFlags, secrets)
+		var useKerberosCache, err = d.ensureKerberosCache(d.krb5CacheDirectory, d.krb5Prefix, volumeID, mountFlags, secrets)
 		if err != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("Error writing kerberos cache: %v", err))
 		}
@@ -583,62 +582,57 @@ func getKerberosCache(krb5CacheDirectory, krb5Prefix string, credUID int, secret
 	return krb5CacheFileName, content, nil
 }
 
-var cruidLocks sync.Map // map[int]*sync.Mutex
-
-func getCruidLock(cruid int) *sync.Mutex {
-	val, _ := cruidLocks.LoadOrStore(cruid, &sync.Mutex{})
-	return val.(*sync.Mutex)
-}
-
 // Create kerberos cache in the file based on the VolumeID, so it can be cleaned up during unstage
 // At the same time, kerberos expects to find cache in file named "krb5cc_*", so creating symlink
 // will allow both clean up and serving proper cache to the kerberos.
 // If symlink already exists, ignore it.
-func ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountFlags []string, secrets map[string]string) (bool, error) {
-	var securityIsKerberos = hasKerberosMountOption(mountFlags)
-	if securityIsKerberos {
-		_, err := kerberosCacheDirectoryExists(krb5CacheDirectory)
-		if err != nil {
-			return false, err
-		}
-		credUID, err := getCredUID(mountFlags)
-		if err != nil {
-			return false, err
-		}
-		krb5CacheFileName, content, err := getKerberosCache(krb5CacheDirectory, krb5Prefix, credUID, secrets)
-		if err != nil {
-			return false, err
-		}
-
-		volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
-		volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
-
-		if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
-			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't write kerberos cache to file %s: %v", volumeIDCacheAbsolutePath, err))
-		}
-		if err := os.Chown(volumeIDCacheAbsolutePath, credUID, credUID); err != nil {
-			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't chown kerberos cache %s to user %d: %v", volumeIDCacheAbsolutePath, credUID, err))
-		}
-
-		lock := getCruidLock(credUID)
-		lock.Lock()
-		defer lock.Unlock()
-
-		if _, err := os.Stat(krb5CacheFileName); os.IsNotExist(err) {
-			klog.V(2).Infof("Symlink file doesn't exist, it will be created [%s]", krb5CacheFileName)
-		} else {
-			if err := os.Remove(krb5CacheFileName); err != nil {
-				klog.Warningf("Couldn't delete the file [%s]: %v", krb5CacheFileName, err)
-			}
-		}
-
-		if err := os.Symlink(volumeIDCacheAbsolutePath, krb5CacheFileName); err != nil {
-			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create symlink to a cache file %s->%s for user %d: %v", krb5CacheFileName, volumeIDCacheFileName, credUID, err))
-		}
-
-		return true, nil
+func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountFlags []string, secrets map[string]string) (bool, error) {
+	if !hasKerberosMountOption(mountFlags) {
+		return false, nil
 	}
-	return false, nil
+
+	_, err := kerberosCacheDirectoryExists(krb5CacheDirectory)
+	if err != nil {
+		return false, err
+	}
+	credUID, err := getCredUID(mountFlags)
+	if err != nil {
+		return false, err
+	}
+	krb5CacheFileName, content, err := getKerberosCache(krb5CacheDirectory, krb5Prefix, credUID, secrets)
+	if err != nil {
+		return false, err
+	}
+
+	volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
+	volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
+
+	if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
+		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't write kerberos cache to file %s: %v", volumeIDCacheAbsolutePath, err))
+	}
+	if err := os.Chown(volumeIDCacheAbsolutePath, credUID, credUID); err != nil {
+		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't chown kerberos cache %s to user %d: %v", volumeIDCacheAbsolutePath, credUID, err))
+	}
+
+	cruidLockKey := fmt.Sprintf("cruid-%d", credUID)
+	if acquired := d.volumeLocks.TryAcquire(cruidLockKey); !acquired {
+		return false, status.Errorf(codes.Aborted, volumeOperationAlreadyExistsFmt, cruidLockKey)
+	}
+	defer d.volumeLocks.Release(cruidLockKey)
+
+	if _, err := os.Stat(krb5CacheFileName); os.IsNotExist(err) {
+		klog.V(2).Infof("Symlink file doesn't exist, it will be created [%s]", krb5CacheFileName)
+	} else {
+		if err := os.Remove(krb5CacheFileName); err != nil {
+			klog.Warningf("Couldn't delete the file [%s]: %v", krb5CacheFileName, err)
+		}
+	}
+
+	if err := os.Symlink(volumeIDCacheAbsolutePath, krb5CacheFileName); err != nil {
+		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create symlink to a cache file %s->%s for user %d: %v", krb5CacheFileName, volumeIDCacheFileName, credUID, err))
+	}
+
+	return true, nil
 }
 
 func deleteKerberosCache(krb5CacheDirectory, volumeID string) error {

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -586,7 +586,8 @@ func getKerberosCache(krb5CacheDirectory, krb5Prefix string, credUID int, secret
 // At the same time, kerberos expects to find cache in file named "krb5cc_*", so creating symlink
 // will allow both clean up and serving proper cache to the kerberos.
 // If a valid symlink already exists (pointing to a readable cache file), it is kept as-is
-// to avoid disrupting concurrent mounts. Dangling or non-symlink entries are replaced.
+// to avoid disrupting concurrent mounts. Dangling symlinks, regular files, and directories
+// are replaced.
 func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountFlags []string, secrets map[string]string) (bool, error) {
 	if !hasKerberosMountOption(mountFlags) {
 		return false, nil
@@ -630,8 +631,13 @@ func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID st
 				klog.V(2).Infof("Valid symlink already exists [%s -> %s], leaving it alone for concurrent mount.", krb5CacheFileName, symlinkTarget)
 				shouldCreateSymlink = false
 			}
+		} else if fileInfo.IsDir() {
+			// A directory cannot be atomically replaced by os.Rename; remove it first.
+			if err := os.RemoveAll(krb5CacheFileName); err != nil {
+				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't remove unexpected directory at kerberos cache path %s: %v", krb5CacheFileName, err))
+			}
 		}
-		// Do not remove the existing path here; rely on os.Rename's atomic
+		// For regular files or dangling symlinks, rely on os.Rename's atomic
 		// replace to avoid a window where krb5CacheFileName is missing.
 	} else if !os.IsNotExist(statErr) {
 		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't inspect kerberos cache path %s: %v", krb5CacheFileName, statErr))

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -585,7 +585,7 @@ func getKerberosCache(krb5CacheDirectory, krb5Prefix string, credUID int, secret
 // Create kerberos cache in the file based on the VolumeID, so it can be cleaned up during unstage
 // At the same time, kerberos expects to find cache in file named "krb5cc_*", so creating symlink
 // will allow both clean up and serving proper cache to the kerberos.
-// If symlink already exist, ignore it
+// If symlink already exists, ignore it
 func ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountFlags []string, secrets map[string]string) (bool, error) {
     var securityIsKerberos = hasKerberosMountOption(mountFlags)
     if securityIsKerberos {

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -585,48 +585,50 @@ func getKerberosCache(krb5CacheDirectory, krb5Prefix string, credUID int, secret
 // Create kerberos cache in the file based on the VolumeID, so it can be cleaned up during unstage
 // At the same time, kerberos expects to find cache in file named "krb5cc_*", so creating symlink
 // will allow both clean up and serving proper cache to the kerberos.
+// If symlink already exist, ignore it
 func ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountFlags []string, secrets map[string]string) (bool, error) {
-	var securityIsKerberos = hasKerberosMountOption(mountFlags)
-	if securityIsKerberos {
-		_, err := kerberosCacheDirectoryExists(krb5CacheDirectory)
-		if err != nil {
-			return false, err
-		}
-		credUID, err := getCredUID(mountFlags)
-		if err != nil {
-			return false, err
-		}
-		krb5CacheFileName, content, err := getKerberosCache(krb5CacheDirectory, krb5Prefix, credUID, secrets)
-		if err != nil {
-			return false, err
-		}
-		// Write cache into volumeId-based filename, so it can be cleaned up later
-		volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
+    var securityIsKerberos = hasKerberosMountOption(mountFlags)
+    if securityIsKerberos {
+        _, err := kerberosCacheDirectoryExists(krb5CacheDirectory)
+        if err != nil {
+            return false, err
+        }
+        credUID, err := getCredUID(mountFlags)
+        if err != nil {
+            return false, err
+        }
+        krb5CacheFileName, content, err := getKerberosCache(krb5CacheDirectory, krb5Prefix, credUID, secrets)
+        if err != nil {
+            return false, err
+        }
+        volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
 
-		volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
-		if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
-			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't write kerberos cache to file %s: %v", volumeIDCacheAbsolutePath, err))
-		}
-		if err := os.Chown(volumeIDCacheAbsolutePath, credUID, credUID); err != nil {
-			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't chown kerberos cache %s to user %d: %v", volumeIDCacheAbsolutePath, credUID, err))
-		}
+        volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
+        if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
+            return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't write kerberos cache to file %s: %v", volumeIDCacheAbsolutePath, err))
+        }
+        if err := os.Chown(volumeIDCacheAbsolutePath, credUID, credUID); err != nil {
+            return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't chown kerberos cache %s to user %d: %v", volumeIDCacheAbsolutePath, credUID, err))
+        }
 
-		if _, err := os.Stat(krb5CacheFileName); os.IsNotExist(err) {
-			klog.Warningf("symlink file doesn't exist, it'll be created [%s]", krb5CacheFileName)
-		} else {
-			if err := os.Remove(krb5CacheFileName); err != nil {
-				klog.Warningf("couldn't delete the file [%s]", krb5CacheFileName)
-			}
-		}
+        _, statErr := os.Stat(krb5CacheFileName)
+        if statErr == nil {
+            klog.V(2).Infof("Valid symlink already exists [%s], leaving it alone for concurrent mount.", krb5CacheFileName)
+        } else {
+            os.Remove(krb5CacheFileName)
 
-		// Create symlink to the cache file with expected name
-		if err := os.Symlink(volumeIDCacheAbsolutePath, krb5CacheFileName); err != nil {
-			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create symlink to a cache file %s->%s to user %d: %v", krb5CacheFileName, volumeIDCacheFileName, credUID, err))
-		}
+            if err := os.Symlink(volumeIDCacheAbsolutePath, krb5CacheFileName); err != nil {
+                if os.IsExist(err) {
+                    klog.V(2).Infof("Symlink %s was just created by another thread, continuing.", krb5CacheFileName)
+                } else {
+                    return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create symlink: %v", err))
+                }
+            }
+        }
 
-		return true, nil
-	}
-	return false, nil
+        return true, nil
+    }
+    return false, nil
 }
 
 func deleteKerberosCache(krb5CacheDirectory, volumeID string) error {

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -609,7 +609,9 @@ func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID st
 	if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
 		return false, status.Error(codes.Internal, fmt.Sprintf("failed to write kerberos cache %s: %v", volumeIDCacheAbsolutePath, err))
 	}
-	if err := os.Chown(volumeIDCacheAbsolutePath, credUID, credUID); err != nil {
+	// Use gid -1 to leave the group unchanged; this avoids EPERM when the
+	// process uid != gid and the caller is not root (e.g., unit-test environments).
+	if err := os.Chown(volumeIDCacheAbsolutePath, credUID, -1); err != nil {
 		return false, status.Error(codes.Internal, fmt.Sprintf("failed to chown kerberos cache %s to uid %d: %v", volumeIDCacheAbsolutePath, credUID, err))
 	}
 

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -582,12 +582,10 @@ func getKerberosCache(krb5CacheDirectory, krb5Prefix string, credUID int, secret
 	return krb5CacheFileName, content, nil
 }
 
-// Create kerberos cache in the file based on the VolumeID, so it can be cleaned up during unstage
-// At the same time, kerberos expects to find cache in file named "krb5cc_*", so creating symlink
-// will allow both clean up and serving proper cache to the kerberos.
-// If a valid symlink already exists (pointing to a readable cache file), it is kept as-is
-// to avoid disrupting concurrent mounts. Dangling symlinks, regular files, and directories
-// are replaced.
+// ensureKerberosCache writes a volume-specific kerberos cache file and
+// creates (or atomically updates) the krb5cc_<uid> symlink to point at it.
+// Concurrent callers for the same cruid are safe: each writes its own cache
+// file and the symlink is updated via temp-symlink + rename (atomic on Linux).
 func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountFlags []string, secrets map[string]string) (bool, error) {
 	if !hasKerberosMountOption(mountFlags) {
 		return false, nil
@@ -605,84 +603,33 @@ func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID st
 	if err != nil {
 		return false, err
 	}
-	volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
 
-	volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
+	// Write cache into volume-specific file so it can be cleaned up during unstage.
+	volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeKerberosCacheName(volumeID))
 	if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
-		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't write kerberos cache to file %s: %v", volumeIDCacheAbsolutePath, err))
+		return false, status.Error(codes.Internal, fmt.Sprintf("failed to write kerberos cache %s: %v", volumeIDCacheAbsolutePath, err))
 	}
 	if err := os.Chown(volumeIDCacheAbsolutePath, credUID, credUID); err != nil {
-		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't chown kerberos cache %s to user %d: %v", volumeIDCacheAbsolutePath, credUID, err))
+		return false, status.Error(codes.Internal, fmt.Sprintf("failed to chown kerberos cache %s to uid %d: %v", volumeIDCacheAbsolutePath, credUID, err))
 	}
 
-	// Check if a valid symlink already exists — if so, leave it alone for concurrent mounts.
-	// Use Lstat so a dangling symlink is still detected as present.
-	shouldCreateSymlink := true
-	fileInfo, statErr := os.Lstat(krb5CacheFileName)
-	if statErr == nil {
-		if fileInfo.Mode()&os.ModeSymlink != 0 {
-			symlinkTarget, readErr := os.Readlink(krb5CacheFileName)
-			if readErr != nil {
-				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't read symlink %s: %v", krb5CacheFileName, readErr))
-			}
-			// Accept any existing symlink that points to a valid, readable cache file.
-			// This avoids racing with concurrent mounts for the same cruid but different volumes.
-			if _, targetErr := os.Stat(krb5CacheFileName); targetErr == nil {
-				klog.V(2).Infof("Valid symlink already exists [%s -> %s], leaving it alone for concurrent mount.", krb5CacheFileName, symlinkTarget)
-				shouldCreateSymlink = false
-			}
-		} else if fileInfo.IsDir() {
-			// A directory cannot be atomically replaced by os.Rename; remove it first.
-			if err := os.RemoveAll(krb5CacheFileName); err != nil {
-				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't remove unexpected directory at kerberos cache path %s: %v", krb5CacheFileName, err))
-			}
+	// Atomic symlink update: create temp symlink then rename over the target.
+	// os.Rename on Linux atomically replaces files and symlinks (but not directories).
+	if info, err := os.Lstat(krb5CacheFileName); err == nil && info.IsDir() {
+		if err := os.RemoveAll(krb5CacheFileName); err != nil {
+			return false, status.Error(codes.Internal, fmt.Sprintf("failed to remove directory at kerberos cache path %s: %v", krb5CacheFileName, err))
 		}
-		// For regular files or dangling symlinks, rely on os.Rename's atomic
-		// replace to avoid a window where krb5CacheFileName is missing.
-	} else if !os.IsNotExist(statErr) {
-		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't inspect kerberos cache path %s: %v", krb5CacheFileName, statErr))
 	}
 
-	if shouldCreateSymlink {
-		// Use atomic temp-symlink + rename to avoid a window where krb5CacheFileName is missing.
-		created := false
-		var tempSymlinkName string
-		for attempt := 0; attempt < 5; attempt++ {
-			tempSymlinkName = filepath.Join(filepath.Dir(krb5CacheFileName), fmt.Sprintf(".%s.tmp.%d", filepath.Base(krb5CacheFileName), time.Now().UnixNano()))
-			if err := os.Symlink(volumeIDCacheAbsolutePath, tempSymlinkName); err != nil {
-				if os.IsExist(err) {
-					klog.V(2).Infof("Temporary symlink path %s already exists, retrying.", tempSymlinkName)
-					continue
-				}
-				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create temporary symlink %s -> %s for credUID %d: %v", tempSymlinkName, volumeIDCacheAbsolutePath, credUID, err))
-			}
-			created = true
-			break
-		}
-		if !created {
-			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create temporary symlink for kerberos cache %s after retries", krb5CacheFileName))
-		}
-
-		if err := os.Rename(tempSymlinkName, krb5CacheFileName); err != nil {
-			// On Linux, Rename replaces the target atomically; this branch is
-			// only expected on systems where rename-over-existing fails (e.g.,
-			// certain Windows/NFS edge cases). Only retry when the target
-			// already exists; for other errors (permission, I/O) fail fast.
-			if !os.IsExist(err) {
-				os.Remove(tempSymlinkName)
-				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't atomically update kerberos symlink %s -> %s for credUID %d: %v", krb5CacheFileName, volumeIDCacheAbsolutePath, credUID, err))
-			}
-			if removeErr := os.Remove(krb5CacheFileName); removeErr != nil && !os.IsNotExist(removeErr) {
-				os.Remove(tempSymlinkName)
-				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't replace kerberos symlink %s: rename failed: %v, remove failed: %v", krb5CacheFileName, err, removeErr))
-			}
-			if retryErr := os.Rename(tempSymlinkName, krb5CacheFileName); retryErr != nil {
-				os.Remove(tempSymlinkName)
-				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't atomically update kerberos symlink %s -> %s for credUID %d: %v", krb5CacheFileName, volumeIDCacheAbsolutePath, credUID, retryErr))
-			}
-		}
-		klog.V(2).Infof("Updated kerberos symlink %s -> %s", krb5CacheFileName, volumeIDCacheAbsolutePath)
+	tempSymlink := fmt.Sprintf("%s.tmp.%d", krb5CacheFileName, time.Now().UnixNano())
+	if err := os.Symlink(volumeIDCacheAbsolutePath, tempSymlink); err != nil {
+		return false, status.Error(codes.Internal, fmt.Sprintf("failed to create temp symlink %s -> %s: %v", tempSymlink, volumeIDCacheAbsolutePath, err))
 	}
+	if err := os.Rename(tempSymlink, krb5CacheFileName); err != nil {
+		os.Remove(tempSymlink)
+		return false, status.Error(codes.Internal, fmt.Sprintf("failed to rename symlink %s -> %s: %v", tempSymlink, krb5CacheFileName, err))
+	}
+	klog.V(2).Infof("Updated kerberos symlink %s -> %s", krb5CacheFileName, volumeIDCacheAbsolutePath)
 
 	return true, nil
 }

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -631,11 +631,8 @@ func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID st
 				shouldCreateSymlink = false
 			}
 		}
-		if shouldCreateSymlink {
-			if err := os.Remove(krb5CacheFileName); err != nil && !os.IsNotExist(err) {
-				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't remove existing kerberos cache path %s: %v", krb5CacheFileName, err))
-			}
-		}
+		// Do not remove the existing path here; rely on os.Rename's atomic
+		// replace to avoid a window where krb5CacheFileName is missing.
 	} else if !os.IsNotExist(statErr) {
 		return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't inspect kerberos cache path %s: %v", krb5CacheFileName, statErr))
 	}

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -587,48 +587,48 @@ func getKerberosCache(krb5CacheDirectory, krb5Prefix string, credUID int, secret
 // will allow both clean up and serving proper cache to the kerberos.
 // If symlink already exists, ignore it
 func ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountFlags []string, secrets map[string]string) (bool, error) {
-    var securityIsKerberos = hasKerberosMountOption(mountFlags)
-    if securityIsKerberos {
-        _, err := kerberosCacheDirectoryExists(krb5CacheDirectory)
-        if err != nil {
-            return false, err
-        }
-        credUID, err := getCredUID(mountFlags)
-        if err != nil {
-            return false, err
-        }
-        krb5CacheFileName, content, err := getKerberosCache(krb5CacheDirectory, krb5Prefix, credUID, secrets)
-        if err != nil {
-            return false, err
-        }
-        volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
+	var securityIsKerberos = hasKerberosMountOption(mountFlags)
+	if securityIsKerberos {
+		_, err := kerberosCacheDirectoryExists(krb5CacheDirectory)
+		if err != nil {
+			return false, err
+		}
+		credUID, err := getCredUID(mountFlags)
+		if err != nil {
+			return false, err
+		}
+		krb5CacheFileName, content, err := getKerberosCache(krb5CacheDirectory, krb5Prefix, credUID, secrets)
+		if err != nil {
+			return false, err
+		}
+		volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
 
-        volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
-        if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
-            return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't write kerberos cache to file %s: %v", volumeIDCacheAbsolutePath, err))
-        }
-        if err := os.Chown(volumeIDCacheAbsolutePath, credUID, credUID); err != nil {
-            return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't chown kerberos cache %s to user %d: %v", volumeIDCacheAbsolutePath, credUID, err))
-        }
+		volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
+		if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
+			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't write kerberos cache to file %s: %v", volumeIDCacheAbsolutePath, err))
+		}
+		if err := os.Chown(volumeIDCacheAbsolutePath, credUID, credUID); err != nil {
+			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't chown kerberos cache %s to user %d: %v", volumeIDCacheAbsolutePath, credUID, err))
+		}
 
-        _, statErr := os.Stat(krb5CacheFileName)
-        if statErr == nil {
-            klog.V(2).Infof("Valid symlink already exists [%s], leaving it alone for concurrent mount.", krb5CacheFileName)
-        } else {
-            os.Remove(krb5CacheFileName)
+		_, statErr := os.Stat(krb5CacheFileName)
+		if statErr == nil {
+			klog.V(2).Infof("Valid symlink already exists [%s], leaving it alone for concurrent mount.", krb5CacheFileName)
+		} else {
+			os.Remove(krb5CacheFileName)
 
-            if err := os.Symlink(volumeIDCacheAbsolutePath, krb5CacheFileName); err != nil {
-                if os.IsExist(err) {
-                    klog.V(2).Infof("Symlink %s was just created by another thread, continuing.", krb5CacheFileName)
-                } else {
-                    return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create symlink: %v", err))
-                }
-            }
-        }
+			if err := os.Symlink(volumeIDCacheAbsolutePath, krb5CacheFileName); err != nil {
+				if os.IsExist(err) {
+					klog.V(2).Infof("Symlink %s was just created by another thread, continuing.", krb5CacheFileName)
+				} else {
+					return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create symlink: %v", err))
+				}
+			}
+		}
 
-        return true, nil
-    }
-    return false, nil
+		return true, nil
+	}
+	return false, nil
 }
 
 func deleteKerberosCache(krb5CacheDirectory, volumeID string) error {

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -585,7 +585,8 @@ func getKerberosCache(krb5CacheDirectory, krb5Prefix string, credUID int, secret
 // Create kerberos cache in the file based on the VolumeID, so it can be cleaned up during unstage
 // At the same time, kerberos expects to find cache in file named "krb5cc_*", so creating symlink
 // will allow both clean up and serving proper cache to the kerberos.
-// If symlink already exists, ignore it.
+// If a valid symlink already exists (pointing to a readable cache file), it is kept as-is
+// to avoid disrupting concurrent mounts. Dangling or non-symlink entries are replaced.
 func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountFlags []string, secrets map[string]string) (bool, error) {
 	if !hasKerberosMountOption(mountFlags) {
 		return false, nil
@@ -660,6 +661,14 @@ func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID st
 		}
 
 		if err := os.Rename(tempSymlinkName, krb5CacheFileName); err != nil {
+			// On Linux, Rename replaces the target atomically; this branch is
+			// only expected on systems where rename-over-existing fails (e.g.,
+			// certain Windows/NFS edge cases). Only retry when the target
+			// already exists; for other errors (permission, I/O) fail fast.
+			if !os.IsExist(err) {
+				os.Remove(tempSymlinkName)
+				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't atomically update kerberos symlink %s -> %s for credUID %d: %v", krb5CacheFileName, volumeIDCacheAbsolutePath, credUID, err))
+			}
 			if removeErr := os.Remove(krb5CacheFileName); removeErr != nil && !os.IsNotExist(removeErr) {
 				os.Remove(tempSymlinkName)
 				return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't replace kerberos symlink %s: rename failed: %v, remove failed: %v", krb5CacheFileName, err, removeErr))

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -620,7 +620,10 @@ func (d *Driver) ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID st
 	}
 	defer d.volumeLocks.Release(cruidLockKey)
 
-	if _, err := os.Stat(krb5CacheFileName); os.IsNotExist(err) {
+	// Use Lstat so a dangling symlink is still detected as present — os.Stat
+	// would follow the link and report ENOENT, causing the subsequent Symlink
+	// to fail with "file exists".
+	if _, err := os.Lstat(krb5CacheFileName); os.IsNotExist(err) {
 		klog.V(2).Infof("Symlink file doesn't exist, it will be created [%s]", krb5CacheFileName)
 	} else {
 		if err := os.Remove(krb5CacheFileName); err != nil {

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -582,10 +583,17 @@ func getKerberosCache(krb5CacheDirectory, krb5Prefix string, credUID int, secret
 	return krb5CacheFileName, content, nil
 }
 
+var cruidLocks sync.Map // map[int]*sync.Mutex
+
+func getCruidLock(cruid int) *sync.Mutex {
+	val, _ := cruidLocks.LoadOrStore(cruid, &sync.Mutex{})
+	return val.(*sync.Mutex)
+}
+
 // Create kerberos cache in the file based on the VolumeID, so it can be cleaned up during unstage
 // At the same time, kerberos expects to find cache in file named "krb5cc_*", so creating symlink
 // will allow both clean up and serving proper cache to the kerberos.
-// If symlink already exists, ignore it
+// If symlink already exists, ignore it.
 func ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountFlags []string, secrets map[string]string) (bool, error) {
 	var securityIsKerberos = hasKerberosMountOption(mountFlags)
 	if securityIsKerberos {
@@ -601,9 +609,10 @@ func ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountF
 		if err != nil {
 			return false, err
 		}
-		volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
 
+		volumeIDCacheFileName := volumeKerberosCacheName(volumeID)
 		volumeIDCacheAbsolutePath := getKerberosFilePath(krb5CacheDirectory, volumeIDCacheFileName)
+
 		if err := os.WriteFile(volumeIDCacheAbsolutePath, content, os.FileMode(0700)); err != nil {
 			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't write kerberos cache to file %s: %v", volumeIDCacheAbsolutePath, err))
 		}
@@ -611,19 +620,20 @@ func ensureKerberosCache(krb5CacheDirectory, krb5Prefix, volumeID string, mountF
 			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't chown kerberos cache %s to user %d: %v", volumeIDCacheAbsolutePath, credUID, err))
 		}
 
-		_, statErr := os.Stat(krb5CacheFileName)
-		if statErr == nil {
-			klog.V(2).Infof("Valid symlink already exists [%s], leaving it alone for concurrent mount.", krb5CacheFileName)
-		} else {
-			os.Remove(krb5CacheFileName)
+		lock := getCruidLock(credUID)
+		lock.Lock()
+		defer lock.Unlock()
 
-			if err := os.Symlink(volumeIDCacheAbsolutePath, krb5CacheFileName); err != nil {
-				if os.IsExist(err) {
-					klog.V(2).Infof("Symlink %s was just created by another thread, continuing.", krb5CacheFileName)
-				} else {
-					return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create symlink: %v", err))
-				}
+		if _, err := os.Stat(krb5CacheFileName); os.IsNotExist(err) {
+			klog.V(2).Infof("Symlink file doesn't exist, it will be created [%s]", krb5CacheFileName)
+		} else {
+			if err := os.Remove(krb5CacheFileName); err != nil {
+				klog.Warningf("Couldn't delete the file [%s]: %v", krb5CacheFileName, err)
 			}
+		}
+
+		if err := os.Symlink(volumeIDCacheAbsolutePath, krb5CacheFileName); err != nil {
+			return false, status.Error(codes.Internal, fmt.Sprintf("Couldn't create symlink to a cache file %s->%s for user %d: %v", krb5CacheFileName, volumeIDCacheFileName, credUID, err))
 		}
 
 		return true, nil

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -1065,8 +1065,8 @@ func TestEnsureKerberosCache(t *testing.T) {
 }
 
 // Regression test for the race where parallel kubelet mounts sharing a CRUID
-// collided on the shared krb5cc_<uid> symlink. Runs many goroutines against the
-// per-CRUID lock and asserts no caller observes a "file exists" from Symlink
+// collided on the shared krb5cc_<uid> symlink. Runs many goroutines concurrently
+// and asserts that atomic temp-symlink-then-rename avoids "file exists" errors
 // and that the final symlink points at a valid volume-specific cache file.
 func TestEnsureKerberosCacheConcurrent(t *testing.T) {
 	if runtime.GOOS != "linux" {

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -1069,7 +1069,6 @@ func TestEnsureKerberosCache(t *testing.T) {
 			if _, err := os.Stat(target); err != nil {
 				t.Fatalf("symlink target %s must be valid: %v", target, err)
 			}
-			}
 		})
 	}
 }

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -1121,9 +1121,14 @@ func TestEnsureKerberosCacheConcurrent(t *testing.T) {
 	if _, err := os.Stat(target); err != nil {
 		t.Fatalf("symlink target %s does not exist: %v", target, err)
 	}
-	// Verify the target is a volume-specific cache file (named vol-<N>)
-	if !strings.Contains(target, "vol-") {
-		t.Errorf("expected symlink target to be a volume-specific cache file, got %s", target)
+	// Verify the target is a volume-specific cache file (base64-encoded volumeID)
+	targetBase := filepath.Base(target)
+	decoded, err := base64.URLEncoding.DecodeString(targetBase)
+	if err != nil {
+		decoded, err = base64.StdEncoding.DecodeString(targetBase)
+	}
+	if err != nil || !strings.HasPrefix(string(decoded), "vol-") {
+		t.Errorf("expected symlink target to be a volume-specific cache file (base64 of vol-*), got %s (decoded: %s)", target, string(decoded))
 	}
 }
 

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -982,6 +982,86 @@ func TestGetKerberosCache(t *testing.T) {
 
 }
 
+// Covers the three observable states of the shared krb5cc_<uid> symlink prior
+// to ensureKerberosCache: no link, a valid link from a previous volume, and a
+// dangling link whose target has been cleaned up. The dangling case is the
+// regression guard for the os.Stat -> os.Lstat fix.
+func TestEnsureKerberosCache(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("ensureKerberosCache is only used on Linux")
+	}
+
+	credUID := os.Getuid()
+	krb5Prefix := "krb5cc_"
+	ticket := []byte{'G', 'O', 'L', 'A', 'N', 'G'}
+	base64Ticket := base64.StdEncoding.EncodeToString(ticket)
+	secrets := map[string]string{
+		fmt.Sprintf("%s%d", krb5Prefix, credUID): base64Ticket,
+	}
+	mountFlags := []string{"sec=krb5", fmt.Sprintf("cruid=%d", credUID)}
+	volumeID := "vol-1"
+
+	tests := []struct {
+		desc  string
+		setup func(t *testing.T, krb5Dir, symlinkPath string)
+	}{
+		{
+			desc:  "no existing symlink",
+			setup: func(_ *testing.T, _, _ string) {},
+		},
+		{
+			desc: "valid symlink from a previous volume is replaced",
+			setup: func(t *testing.T, krb5Dir, symlinkPath string) {
+				previous := krb5Dir + "previous-volume-cache"
+				if err := os.WriteFile(previous, []byte("old"), 0600); err != nil {
+					t.Fatalf("setup WriteFile: %v", err)
+				}
+				if err := os.Symlink(previous, symlinkPath); err != nil {
+					t.Fatalf("setup Symlink: %v", err)
+				}
+			},
+		},
+		{
+			desc: "dangling symlink is replaced",
+			setup: func(t *testing.T, krb5Dir, symlinkPath string) {
+				if err := os.Symlink(krb5Dir+"gone", symlinkPath); err != nil {
+					t.Fatalf("setup Symlink: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			krb5Dir := t.TempDir() + "/"
+			d := NewFakeDriver()
+			symlinkPath := getKerberosFilePath(krb5Dir, getKrb5CcacheName(krb5Prefix, credUID))
+
+			tc.setup(t, krb5Dir, symlinkPath)
+
+			used, err := d.ensureKerberosCache(krb5Dir, krb5Prefix, volumeID, mountFlags, secrets)
+			if err != nil {
+				t.Fatalf("ensureKerberosCache: %v", err)
+			}
+			if !used {
+				t.Fatalf("expected useKerberosCache=true")
+			}
+
+			target, err := os.Readlink(symlinkPath)
+			if err != nil {
+				t.Fatalf("readlink %s: %v", symlinkPath, err)
+			}
+			expected := getKerberosFilePath(krb5Dir, volumeKerberosCacheName(volumeID))
+			if target != expected {
+				t.Errorf("symlink target = %s, want %s", target, expected)
+			}
+			if _, err := os.Stat(target); err != nil {
+				t.Fatalf("symlink target %s must be valid: %v", target, err)
+			}
+		})
+	}
+}
+
 // Regression test for the race where parallel kubelet mounts sharing a CRUID
 // collided on the shared krb5cc_<uid> symlink. Runs many goroutines against the
 // per-CRUID lock and asserts no caller observes a "file exists" from Symlink

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -979,6 +980,58 @@ func TestGetKerberosCache(t *testing.T) {
 		}
 	}
 
+}
+
+// Regression test for the race where parallel kubelet mounts sharing a CRUID
+// collided on the shared krb5cc_<uid> symlink. Runs many goroutines against the
+// per-CRUID lock and asserts no caller observes a "file exists" from Symlink
+// and that the final symlink points at a valid volume-specific cache file.
+func TestEnsureKerberosCacheConcurrent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ensureKerberosCache is only used on Linux")
+	}
+
+	krb5Dir := t.TempDir() + "/"
+	d := NewFakeDriver()
+
+	credUID := os.Getuid()
+	krb5Prefix := "krb5cc_"
+	ticket := []byte{'G', 'O', 'L', 'A', 'N', 'G'}
+	base64Ticket := base64.StdEncoding.EncodeToString(ticket)
+	secrets := map[string]string{
+		fmt.Sprintf("%s%d", krb5Prefix, credUID): base64Ticket,
+	}
+	mountFlags := []string{"sec=krb5", fmt.Sprintf("cruid=%d", credUID)}
+
+	const nGoroutines = 8
+	var wg sync.WaitGroup
+	errCh := make(chan error, nGoroutines)
+	for i := 0; i < nGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			volumeID := fmt.Sprintf("vol-%d", idx)
+			_, err := d.ensureKerberosCache(krb5Dir, krb5Prefix, volumeID, mountFlags, secrets)
+			// Aborted is acceptable — it's how TryAcquire signals contention.
+			if err != nil && status.Code(err) != codes.Aborted {
+				errCh <- fmt.Errorf("goroutine %d: unexpected error: %v", idx, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for e := range errCh {
+		t.Error(e)
+	}
+
+	symlinkPath := getKerberosFilePath(krb5Dir, getKrb5CcacheName(krb5Prefix, credUID))
+	target, err := os.Readlink(symlinkPath)
+	if err != nil {
+		t.Fatalf("final symlink missing at %s: %v", symlinkPath, err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("symlink target %s does not exist: %v", target, err)
+	}
 }
 
 func TestNodePublishVolumeIdempotentMount(t *testing.T) {

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -1017,7 +1017,7 @@ func TestEnsureKerberosCache(t *testing.T) {
 		{
 			desc: "valid symlink from a previous volume is kept",
 			setup: func(t *testing.T, krb5Dir, symlinkPath string) {
-				previous := krb5Dir + "previous-volume-cache"
+				previous := filepath.Join(krb5Dir, "previous-volume-cache")
 				if err := os.WriteFile(previous, []byte("old"), 0600); err != nil {
 					t.Fatalf("setup WriteFile: %v", err)
 				}
@@ -1029,7 +1029,7 @@ func TestEnsureKerberosCache(t *testing.T) {
 		{
 			desc: "dangling symlink is replaced",
 			setup: func(t *testing.T, krb5Dir, symlinkPath string) {
-				if err := os.Symlink(krb5Dir+"gone", symlinkPath); err != nil {
+				if err := os.Symlink(filepath.Join(krb5Dir, "gone"), symlinkPath); err != nil {
 					t.Fatalf("setup Symlink: %v", err)
 				}
 			},

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -1121,14 +1121,14 @@ func TestEnsureKerberosCacheConcurrent(t *testing.T) {
 	if _, err := os.Stat(target); err != nil {
 		t.Fatalf("symlink target %s does not exist: %v", target, err)
 	}
-	// Verify the target is a volume-specific cache file (base64-encoded volumeID)
+	// Verify the target is a volume-specific cache file.
+	// volumeKerberosCacheName() uses StdEncoding then replaces "/" → "-" and "+" → "_",
+	// so reverse those substitutions before decoding.
 	targetBase := filepath.Base(target)
-	decoded, err := base64.URLEncoding.DecodeString(targetBase)
-	if err != nil {
-		decoded, err = base64.StdEncoding.DecodeString(targetBase)
-	}
+	reversed := strings.ReplaceAll(strings.ReplaceAll(targetBase, "-", "/"), "_", "+")
+	decoded, err := base64.StdEncoding.DecodeString(reversed)
 	if err != nil || !strings.HasPrefix(string(decoded), "vol-") {
-		t.Errorf("expected symlink target to be a volume-specific cache file (base64 of vol-*), got %s (decoded: %s)", target, string(decoded))
+		t.Errorf("expected symlink target to be a base64-encoded vol-* cache file, got %s (decoded: %s, err: %v)", target, string(decoded), err)
 	}
 }
 

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -990,6 +990,11 @@ func TestEnsureKerberosCache(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("ensureKerberosCache is only used on Linux")
 	}
+	// ensureKerberosCache calls os.Chown(path, uid, uid); when uid != gid
+	// this fails with EPERM for non-root users.
+	if os.Getuid() != 0 && os.Getuid() != os.Getgid() {
+		t.Skip("skipping: os.Chown requires root or uid == gid")
+	}
 
 	credUID := os.Getuid()
 	krb5Prefix := "krb5cc_"
@@ -1071,6 +1076,9 @@ func TestEnsureKerberosCache(t *testing.T) {
 func TestEnsureKerberosCacheConcurrent(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("ensureKerberosCache is only used on Linux")
+	}
+	if os.Getuid() != 0 && os.Getuid() != os.Getgid() {
+		t.Skip("skipping: os.Chown requires root or uid == gid")
 	}
 
 	krb5Dir := t.TempDir() + "/"

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -989,9 +989,6 @@ func TestEnsureKerberosCache(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("ensureKerberosCache is only used on Linux")
 	}
-	if os.Getuid() != 0 && os.Getuid() != os.Getgid() {
-		t.Skip("skipping: os.Chown requires root or uid == gid")
-	}
 
 	credUID := os.Getuid()
 	krb5Prefix := "krb5cc_"
@@ -1081,9 +1078,6 @@ func TestEnsureKerberosCacheConcurrent(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("ensureKerberosCache is only used on Linux")
 	}
-	if os.Getuid() != 0 && os.Getuid() != os.Getgid() {
-		t.Skip("skipping: os.Chown requires root or uid == gid")
-	}
 
 	krb5Dir := t.TempDir() + "/"
 	d := NewFakeDriver()
@@ -1125,14 +1119,14 @@ func TestEnsureKerberosCacheConcurrent(t *testing.T) {
 	if _, err := os.Stat(target); err != nil {
 		t.Fatalf("symlink target %s does not exist: %v", target, err)
 	}
-	// Verify the target is a volume-specific cache file.
-	// volumeKerberosCacheName() uses StdEncoding then replaces "/" → "-" and "+" → "_",
-	// so reverse those substitutions before decoding.
+	// Verify the target is one of the expected volume-specific cache files.
 	targetBase := filepath.Base(target)
-	reversed := strings.ReplaceAll(strings.ReplaceAll(targetBase, "-", "/"), "_", "+")
-	decoded, err := base64.StdEncoding.DecodeString(reversed)
-	if err != nil || !strings.HasPrefix(string(decoded), "vol-") {
-		t.Errorf("expected symlink target to be a base64-encoded vol-* cache file, got %s (decoded: %s, err: %v)", target, string(decoded), err)
+	validTargets := make(map[string]bool, nGoroutines)
+	for i := 0; i < nGoroutines; i++ {
+		validTargets[volumeKerberosCacheName(fmt.Sprintf("vol-%d", i))] = true
+	}
+	if !validTargets[targetBase] {
+		t.Errorf("symlink target %s is not a known volume cache file name", target)
 	}
 }
 

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -982,16 +982,13 @@ func TestGetKerberosCache(t *testing.T) {
 
 }
 
-// Covers the three observable states of the shared krb5cc_<uid> symlink prior
-// to ensureKerberosCache: no link, a valid link from a previous volume, and a
-// dangling link whose target has been cleaned up. The dangling case is the
-// regression guard for the os.Stat -> os.Lstat fix.
+// Tests ensureKerberosCache across different initial states of the krb5cc_<uid> path:
+// no existing entry, a valid symlink from a previous volume, a dangling symlink,
+// and a directory (unexpected but should be handled).
 func TestEnsureKerberosCache(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("ensureKerberosCache is only used on Linux")
 	}
-	// ensureKerberosCache calls os.Chown(path, uid, uid); when uid != gid
-	// this fails with EPERM for non-root users.
 	if os.Getuid() != 0 && os.Getuid() != os.Getgid() {
 		t.Skip("skipping: os.Chown requires root or uid == gid")
 	}
@@ -1015,7 +1012,7 @@ func TestEnsureKerberosCache(t *testing.T) {
 			setup: func(_ *testing.T, _, _ string) {},
 		},
 		{
-			desc: "valid symlink from a previous volume is kept",
+			desc: "existing symlink from a previous volume is atomically replaced",
 			setup: func(t *testing.T, krb5Dir, symlinkPath string) {
 				previous := filepath.Join(krb5Dir, "previous-volume-cache")
 				if err := os.WriteFile(previous, []byte("old"), 0600); err != nil {
@@ -1031,6 +1028,14 @@ func TestEnsureKerberosCache(t *testing.T) {
 			setup: func(t *testing.T, krb5Dir, symlinkPath string) {
 				if err := os.Symlink(filepath.Join(krb5Dir, "gone"), symlinkPath); err != nil {
 					t.Fatalf("setup Symlink: %v", err)
+				}
+			},
+		},
+		{
+			desc: "directory at symlink path is replaced",
+			setup: func(t *testing.T, _, symlinkPath string) {
+				if err := os.MkdirAll(symlinkPath, 0755); err != nil {
+					t.Fatalf("setup MkdirAll: %v", err)
 				}
 			},
 		},
@@ -1056,14 +1061,14 @@ func TestEnsureKerberosCache(t *testing.T) {
 			if err != nil {
 				t.Fatalf("readlink %s: %v", symlinkPath, err)
 			}
-			// Symlink must point to a valid, readable cache file.
+			// Symlink must point to current volume's cache file.
+			volCachePath := getKerberosFilePath(krb5Dir, volumeKerberosCacheName(volumeID))
+			if target != volCachePath {
+				t.Errorf("symlink target = %s, want %s", target, volCachePath)
+			}
 			if _, err := os.Stat(target); err != nil {
 				t.Fatalf("symlink target %s must be valid: %v", target, err)
 			}
-			// Volume-specific cache file must also exist.
-			volCachePath := getKerberosFilePath(krb5Dir, volumeKerberosCacheName(volumeID))
-			if _, err := os.Stat(volCachePath); err != nil {
-				t.Fatalf("volume cache file %s must exist: %v", volCachePath, err)
 			}
 		})
 	}

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -1121,6 +1121,10 @@ func TestEnsureKerberosCacheConcurrent(t *testing.T) {
 	if _, err := os.Stat(target); err != nil {
 		t.Fatalf("symlink target %s does not exist: %v", target, err)
 	}
+	// Verify the target is a volume-specific cache file (named vol-<N>)
+	if !strings.Contains(target, "vol-") {
+		t.Errorf("expected symlink target to be a volume-specific cache file, got %s", target)
+	}
 }
 
 func TestNodePublishVolumeIdempotentMount(t *testing.T) {

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -1010,7 +1010,7 @@ func TestEnsureKerberosCache(t *testing.T) {
 			setup: func(_ *testing.T, _, _ string) {},
 		},
 		{
-			desc: "valid symlink from a previous volume is replaced",
+			desc: "valid symlink from a previous volume is kept",
 			setup: func(t *testing.T, krb5Dir, symlinkPath string) {
 				previous := krb5Dir + "previous-volume-cache"
 				if err := os.WriteFile(previous, []byte("old"), 0600); err != nil {
@@ -1051,12 +1051,14 @@ func TestEnsureKerberosCache(t *testing.T) {
 			if err != nil {
 				t.Fatalf("readlink %s: %v", symlinkPath, err)
 			}
-			expected := getKerberosFilePath(krb5Dir, volumeKerberosCacheName(volumeID))
-			if target != expected {
-				t.Errorf("symlink target = %s, want %s", target, expected)
-			}
+			// Symlink must point to a valid, readable cache file.
 			if _, err := os.Stat(target); err != nil {
 				t.Fatalf("symlink target %s must be valid: %v", target, err)
+			}
+			// Volume-specific cache file must also exist.
+			volCachePath := getKerberosFilePath(krb5Dir, volumeKerberosCacheName(volumeID))
+			if _, err := os.Stat(volCachePath); err != nil {
+				t.Fatalf("volume cache file %s must exist: %v", volCachePath, err)
 			}
 		})
 	}
@@ -1092,8 +1094,7 @@ func TestEnsureKerberosCacheConcurrent(t *testing.T) {
 			defer wg.Done()
 			volumeID := fmt.Sprintf("vol-%d", idx)
 			_, err := d.ensureKerberosCache(krb5Dir, krb5Prefix, volumeID, mountFlags, secrets)
-			// Aborted is acceptable — it's how TryAcquire signals contention.
-			if err != nil && status.Code(err) != codes.Aborted {
+			if err != nil {
 				errCh <- fmt.Errorf("goroutine %d: unexpected error: %v", idx, err)
 			}
 		}(i)

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -987,7 +987,7 @@ func TestGetKerberosCache(t *testing.T) {
 // per-CRUID lock and asserts no caller observes a "file exists" from Symlink
 // and that the final symlink points at a valid volume-specific cache file.
 func TestEnsureKerberosCacheConcurrent(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS != "linux" {
 		t.Skip("ensureKerberosCache is only used on Linux")
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a race condition in `ensureKerberosCache` when multiple kerberos volumes with the same `cruid` are mounted concurrently on the same pod.

**Problem:**

When kubelet triggers parallel `NodeStageVolume` calls for multiple volumes sharing the same `cruid`, multiple goroutines enter `ensureKerberosCache` simultaneously. The original code had two race conditions:

1. **Symlink deletion window**: Thread A calls `os.Remove(krb5cc_<cruid>)` to replace the symlink, but before it can call `os.Symlink()`, Thread B's mount executes and fails with `mount error(126): Required key not available` because the symlink is gone.

2. **Symlink creation collision**: Multiple threads call `os.Symlink()` at the same time. The first succeeds, but subsequent threads get `file exists` error and abort the mount.

**Solution:**

Replace the non-atomic remove-then-create symlink logic with atomic **temp-symlink + `os.Rename`**:

1. Each volume writes its own cache file (`<base64(volumeID)>`) — no contention here
2. Create a temp symlink with a unique name (`krb5cc_<uid>.tmp.<nanosecond>`)
3. `os.Rename(temp, krb5cc_<uid>)` — on Linux this atomically replaces the target

This eliminates both races: there is never a window where `krb5cc_<uid>` is missing, and there are no collisions on symlink creation.

**Also includes:**
- Simplify `NodePublishVolume` read-only detection: rely on `req.GetReadonly()` instead of duplicating access-mode and mount-flag checks (the CO is responsible for setting this correctly per CSI spec)

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commits](https://www.conventionalcommits.org/)
- [x] adds unit tests (TestEnsureKerberosCache + TestEnsureKerberosCacheConcurrent)

**Testing:**
- Unit tests cover: no existing symlink, existing valid symlink, dangling symlink, directory at symlink path, and 8-goroutine concurrent race
- Tested on production cluster with 4 simultaneous krb5 PV mounts on the same pod

**Release note**:
```release-note
Fix kerberos cache symlink race condition that caused concurrent SMB krb5 mounts with the same cruid to fail
```