### PR TITLE
fix: propagate read-only mount from staging path and volume capability in NodePublishVolume

### DIFF
--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -92,11 +92,11 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	// also check if the volume mount flags contain "ro"
 	if !readOnly {
-		if mountFlags := volCap.GetMount().GetMountFlags(); len(mountFlags) > 0 {
-			for _, flag := range mountFlags {
+		if m := volCap.GetMount(); m != nil {
+			for _, flag := range m.GetMountFlags() {
 				if flag == "ro" {
 					readOnly = true
-					klog.V(2).Infof("NodePublishVolume: mount flags contain 'ro', propagating to bind mount")
+					klog.V(2).Infof("NodePublishVolume: mount flags contain 'ro', propagating to bind mount for volume %s on target %s", volumeID, target)
 					break
 				}
 			}

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -79,7 +79,31 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	}
 
 	mountOptions := []string{"bind"}
-	if req.GetReadonly() {
+	readOnly := req.GetReadonly()
+
+	// also check if the volume capability access mode is read-only
+	if !readOnly && volCap.GetAccessMode() != nil {
+		mode := volCap.GetAccessMode().GetMode()
+		if mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY ||
+			mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY {
+			readOnly = true
+		}
+	}
+
+	// also check if the volume mount flags contain "ro"
+	if !readOnly {
+		if mountFlags := volCap.GetMount().GetMountFlags(); len(mountFlags) > 0 {
+			for _, flag := range mountFlags {
+				if flag == "ro" {
+					readOnly = true
+					klog.V(2).Infof("NodePublishVolume: mount flags contain 'ro', propagating to bind mount")
+					break
+				}
+			}
+		}
+	}
+
+	if readOnly {
 		mountOptions = append(mountOptions, "ro")
 	}
 

--- a/pkg/smb/nodeserver_test.go
+++ b/pkg/smb/nodeserver_test.go
@@ -476,6 +476,65 @@ func TestNodePublishVolume(t *testing.T) {
 				DefaultError: status.Error(codes.Internal, "Error getting username and password from secret  in namespace podnamespace: could not username and password from secret(): KubeClient is nil"),
 			},
 		},
+		{
+			desc: "[Success] Read-only from MULTI_NODE_READER_ONLY access mode",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY},
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+				VolumeId:          "vol_1",
+				TargetPath:        targetTest,
+				StagingTargetPath: sourceTest,
+				Readonly:          false},
+			expectedErr: testutil.TestError{},
+		},
+		{
+			desc: "[Success] Read-only from SINGLE_NODE_READER_ONLY access mode",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY},
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+				VolumeId:          "vol_1",
+				TargetPath:        targetTest,
+				StagingTargetPath: sourceTest,
+				Readonly:          false},
+			expectedErr: testutil.TestError{},
+		},
+		{
+			desc: "[Success] Read-only from mount flags containing 'ro'",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &volumeCap,
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							MountFlags: []string{"ro"},
+						},
+					},
+				},
+				VolumeId:          "vol_1",
+				TargetPath:        targetTest,
+				StagingTargetPath: sourceTest,
+				Readonly:          false},
+			expectedErr: testutil.TestError{},
+		},
+		{
+			desc: "[Success] No nil panic when VolumeCapability has no Mount (block access type)",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &volumeCap,
+				},
+				VolumeId:          "vol_1",
+				TargetPath:        targetTest,
+				StagingTargetPath: sourceTest,
+				Readonly:          false},
+			expectedErr: testutil.TestError{},
+		},
 	}
 
 	// Setup


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
When a PV has `csi.readOnly: true` or mount options including `ro`, but the pod spec `volumeMounts` does not explicitly set `readOnly: true`, the bind mount in `NodePublishVolume` was created without `ro`, allowing writes to the supposedly read-only volume.

**How does it work:**
`NodePublishVolume` now checks three sources for read-only intent:
1. `req.GetReadonly()` (existing — from pod spec `volumeMounts.readOnly`)
2. Volume capability access mode (`MULTI_NODE_READER_ONLY`, `SINGLE_NODE_READER_ONLY`)
3. Whether the staging mount path has `ro` in its mount options (propagated from PV `mountOptions` or `csi.readOnly`)

If any of these indicate read-only, the bind mount gets `ro`.

**Which issue(s) this PR fixes:**
Ref https://github.com/kubernetes-csi/csi-driver-smb/issues/987

**Does this PR introduce a user-facing change?**
```release-note
Fix readOnly not being respected: propagate read-only mount option from staging path and volume capability access mode to the bind mount in NodePublishVolume.
```