### PR TITLE
test: add control-plane tolerations to smb-server deployments

### DIFF
--- a/deploy/example/smb-provisioner/smb-server-lb.yaml
+++ b/deploy/example/smb-provisioner/smb-server-lb.yaml
@@ -32,6 +32,13 @@ spec:
     spec:
       nodeSelector:
         "kubernetes.io/os": linux
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       containers:
         - name: smb-server
           image: dockurr/samba

--- a/deploy/example/smb-provisioner/smb-server-networkdisk.yaml
+++ b/deploy/example/smb-provisioner/smb-server-networkdisk.yaml
@@ -45,6 +45,13 @@ spec:
     spec:
       nodeSelector:
         "kubernetes.io/os": linux
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       containers:
         - name: smb-server
           image: dperson/samba

--- a/deploy/example/smb-provisioner/smb-server.yaml
+++ b/deploy/example/smb-provisioner/smb-server.yaml
@@ -32,6 +32,13 @@ spec:
     spec:
       nodeSelector:
         "kubernetes.io/os": linux
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       containers:
         - name: smb-server
           image: andyzhangx/samba:win-fix


### PR DESCRIPTION
## What this PR does

Adds `node-role.kubernetes.io/master` and `node-role.kubernetes.io/control-plane` tolerations to all smb-server deployment variants:
- `smb-server.yaml`
- `smb-server-lb.yaml`
- `smb-server-networkdisk.yaml`

## Why

In Windows e2e CI (`pull-csi-driver-smb-e2e-windows-2022-hostprocess`), the CAPZ cluster has:
- 1 Linux control-plane node (with `NoSchedule` taint)
- 2 Windows worker nodes

The `smb-server` pod requires Linux (`nodeSelector: kubernetes.io/os: linux`) but cannot be scheduled because the only Linux node is the control-plane with a `NoSchedule` taint. This causes the pod to stay `Pending` indefinitely, failing tests that depend on the SMB server for volume provisioning.

### Failed tests
- `should create multiple PV objects, bind to PVCs and attach all to different pods on the same node [Windows]`
- `should create a volume on demand and resize it`

### Evidence
From [build log](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-csi_csi-driver-smb/1052/pull-csi-driver-smb-e2e-windows-2022-hostprocess/2046872898995490816/build-log.txt):
```
default  smb-server-68b8554c45-8bf5x  0/1  Pending  0  59m  <none>  <none>
```