### PR TITLE
test: use Quantity.Cmp instead of string comparison in resize volume test

### DIFF
--- a/test/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
@@ -19,7 +19,6 @@ package testsuites
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/kubernetes-csi/csi-driver-smb/test/e2e/driver"
@@ -90,10 +89,8 @@ func (t *DynamicallyProvisionedResizeVolumeTest) Run(ctx context.Context, client
 		ginkgo.By("checking the resizing PV result")
 		newPv, _ := client.CoreV1().PersistentVolumes().Get(ctx, updatedPvc.Spec.VolumeName, metav1.GetOptions{})
 		newPvSize := newPv.Spec.Capacity["storage"]
-		newPvSizeStr := newPvSize.String() + "Gi"
-
-		if !strings.Contains(newPvSizeStr, newSize.String()) {
-			framework.Failf("newPVCSize(%+v) is not equal to newPVSize(%+v)", newSize.String(), newPvSizeStr)
+		if newPvSize.Cmp(newSize) != 0 {
+			framework.Failf("newPVCSize(%s) is not equal to newPVSize(%s)", newSize.String(), newPvSize.String())
 		}
 	}
 }


### PR DESCRIPTION
## What type of PR is this?
/kind failing-test

## What this PR does / why we need it
The resize volume e2e test incorrectly appended `Gi` suffix to `newPvSize.String()`, which already includes the unit, resulting in `10GiGi`. This caused the test to always fail when PV capacity used Gi-suffixed format.

**Error:**
```
[FAILED] newPVCSize(11Gi) is not equal to newPVSize(10GiGi)
```

## How does this PR fix it
Replace string manipulation with `resource.Quantity.Cmp()` for correct semantic comparison. Also removes unused `strings` import.

## Which issue(s) this PR fixes
Fixes flaky e2e test `should create a volume on demand and resize it`

## Does this PR introduce a user-facing change?
```release-note
NONE
```