### PR TITLE
feat: publish container images and Helm chart to GHCR

### DIFF
--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -31,7 +31,7 @@ env:
   REGISTRY: ghcr.io/kubernetes-csi
   IMAGE_NAME: smbplugin
   CHART_NAME: csi-driver-smb
-  GO_VERSION: '1.25.0'
+  GO_VERSION: '1.25.10'
 
 jobs:
   # ── Validate version and compute outputs ───────────────────────────────────

--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -97,13 +97,20 @@ jobs:
           CGO_ENABLED: '0'
           GOOS: linux
         run: |
+          # Use the same output path convention as Makefile:
+          # _output/<goarch>/smbplugin for most arches, _output/arm/v7/smbplugin for armv7
+          if [[ "${{ matrix.goarch }}" == "arm" ]]; then
+            OUT_DIR="_output/arm/v7"
+          else
+            OUT_DIR="_output/${{ matrix.goarch }}"
+          fi
           GIT_COMMIT=$(git rev-parse HEAD)
-          mkdir -p _output/${{ matrix.goarch }}
-          go build -trimpath -ldflags="-s -w \
+          mkdir -p "${OUT_DIR}"
+          go build -a -ldflags "-s -w \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=${{ needs.validate.outputs.version }} \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o _output/${{ matrix.goarch }}/smbplugin ./cmd/smbplugin
+            -mod vendor -o "${OUT_DIR}/smbplugin" ./cmd/smbplugin
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
@@ -121,10 +128,16 @@ jobs:
       - name: Build and push ${{ matrix.platform }}
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
+          # Match Makefile convention: --build-arg ARCH=arm/v7 for armv7
+          if [[ "${{ matrix.goarch }}" == "arm" ]]; then
+            DOCKER_ARCH="arm/v7"
+          else
+            DOCKER_ARCH="${{ matrix.goarch }}"
+          fi
           GIT_COMMIT=$(git rev-parse HEAD)
           docker buildx build --push \
             --platform=${{ matrix.platform }} \
-            --build-arg ARCH=${{ matrix.goarch }} \
+            --build-arg ARCH=${DOCKER_ARCH} \
             --provenance=false --sbom=false \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-${{ matrix.suffix }} \
             --label org.opencontainers.image.revision=${GIT_COMMIT} \
@@ -132,8 +145,8 @@ jobs:
             .
 
   # ── Build & push Windows container images ──────────────────────────────────
-  # Cross-compile Go binary on Linux, then build the Windows container image
-  # on a Windows runner (required for pulling Windows base images).
+  # Build Go binary and container image on Windows runners
+  # (required for pulling Windows base images).
   build-windows:
     needs: [validate]
     strategy:
@@ -164,11 +177,11 @@ jobs:
         run: |
           GIT_COMMIT=$(git rev-parse HEAD)
           mkdir -p _output/amd64
-          go build -trimpath -ldflags="-s -w \
+          go build -a -ldflags "-s -w \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=${{ needs.validate.outputs.version }} \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o _output/amd64/smbplugin.exe ./cmd/smbplugin
+            -mod vendor -o _output/amd64/smbplugin.exe ./cmd/smbplugin
 
       - name: Login to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
@@ -215,11 +228,11 @@ jobs:
         run: |
           GIT_COMMIT=$(git rev-parse HEAD)
           mkdir -p _output/amd64
-          go build -trimpath -ldflags="-s -w \
+          go build -a -ldflags "-s -w \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=${{ needs.validate.outputs.version }} \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o _output/amd64/smbplugin.exe ./cmd/smbplugin
+            -mod vendor -o _output/amd64/smbplugin.exe ./cmd/smbplugin
 
       - name: Login to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
@@ -281,6 +294,8 @@ jobs:
   publish-helm:
     runs-on: ubuntu-latest
     needs: [validate]
+    outputs:
+      helm_chart_version: ${{ steps.verify-version.outputs.helm_chart_version }}
     steps:
       - name: Checkout at version tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -307,6 +322,7 @@ jobs:
         run: helm lint "${{ env.chart_dir }}"
 
       - name: Verify chart version matches
+        id: verify-version
         run: |
           YAML_VERSION=$(grep '^version:' "${{ env.chart_dir }}/Chart.yaml" | awk '{print $2}')
           EXPECTED="${{ needs.validate.outputs.chart_version }}"
@@ -317,6 +333,7 @@ jobs:
             exit 1
           fi
           echo "helm_chart_version=${YAML_VERSION}" >> "$GITHUB_ENV"
+          echo "helm_chart_version=${YAML_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR (Helm)
         run: |
@@ -343,27 +360,26 @@ jobs:
       - name: Job summary
         env:
           VERSION: ${{ needs.validate.outputs.version }}
-          CHART_VERSION: ${{ needs.validate.outputs.chart_version }}
+          CHART_VERSION: ${{ needs.publish-helm.outputs.helm_chart_version || needs.validate.outputs.chart_version }}
         shell: bash
         run: |
           FENCE='```'
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
-          ## Published to GHCR
-
-          ### Container Images
-          | Image | Tag |
-          |-------|-----|
-          | ${REGISTRY}/${IMAGE_NAME} | ${VERSION} (multi-arch manifest) |
-          | ${REGISTRY}/${IMAGE_NAME} | ${VERSION}-windows-hp (HostProcess) |
-
-          ${FENCE}bash
-          docker pull ${REGISTRY}/${IMAGE_NAME}:${VERSION}
-          docker pull ${REGISTRY}/${IMAGE_NAME}:${VERSION}-windows-hp
-          ${FENCE}
-
-          ### Helm Chart (OCI)
-          ${FENCE}bash
-          helm install csi-driver-smb oci://${REGISTRY}/${CHART_NAME} --version ${CHART_VERSION} -n kube-system
-          ${FENCE}
-          EOF
-          sed -i 's/^          //' "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Published to GHCR"
+            echo ""
+            echo "### Container Images"
+            echo "| Image | Tag |"
+            echo "|-------|-----|"
+            echo "| ${REGISTRY}/${IMAGE_NAME} | ${VERSION} (multi-arch manifest) |"
+            echo "| ${REGISTRY}/${IMAGE_NAME} | ${VERSION}-windows-hp (HostProcess) |"
+            echo ""
+            echo "${FENCE}bash"
+            echo "docker pull ${REGISTRY}/${IMAGE_NAME}:${VERSION}"
+            echo "docker pull ${REGISTRY}/${IMAGE_NAME}:${VERSION}-windows-hp"
+            echo "${FENCE}"
+            echo ""
+            echo "### Helm Chart (OCI)"
+            echo "${FENCE}bash"
+            echo "helm install csi-driver-smb oci://${REGISTRY}/${CHART_NAME} --version ${CHART_VERSION} -n kube-system"
+            echo "${FENCE}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -349,7 +349,7 @@ jobs:
       - name: Verify published chart
         run: |
           helm show chart "oci://${REGISTRY}/${CHART_NAME}" \
-            --version "${{ env.helm_chart_version }}"
+            --version "${{ steps.verify-version.outputs.helm_chart_version }}"
 
   # ── Summary ────────────────────────────────────────────────────────────────
   summary:

--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -135,7 +135,7 @@ jobs:
             DOCKER_ARCH="${{ matrix.goarch }}"
           fi
           GIT_COMMIT=$(git rev-parse HEAD)
-          docker buildx build --push \
+          docker buildx build --pull --push \
             --platform=${{ matrix.platform }} \
             --build-arg ARCH=${DOCKER_ARCH} \
             --provenance=false --sbom=false \
@@ -196,7 +196,7 @@ jobs:
           VERSION="${{ needs.validate.outputs.version }}"
           GIT_COMMIT=$(git rev-parse HEAD)
           TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-windows-${{ matrix.osversion }}-amd64"
-          docker build \
+          docker build --pull \
             --build-arg OSVERSION=${{ matrix.osversion }} \
             --label org.opencontainers.image.revision=${GIT_COMMIT} \
             --tag "${TAG}" \
@@ -247,7 +247,7 @@ jobs:
           VERSION="${{ needs.validate.outputs.version }}"
           GIT_COMMIT=$(git rev-parse HEAD)
           TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-windows-hp"
-          docker build \
+          docker build --pull \
             --label org.opencontainers.image.revision=${GIT_COMMIT} \
             --tag "${TAG}" \
             --file ./cmd/smbplugin/Dockerfile.WindowsHostProcess \

--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -282,7 +282,8 @@ jobs:
           # Annotate windows images with os.version for proper platform matching
           for osversion in 1809 ltsc2022; do
             BASEIMAGE="mcr.microsoft.com/windows/nanoserver:${osversion}"
-            full_version=$(docker manifest inspect "${BASEIMAGE}" | jq -r '.manifests[0].platform["os.version"]')
+            full_version=$(docker manifest inspect "${BASEIMAGE}" | \
+              jq -r '.manifests[] | select(.platform.architecture=="amd64") | .platform["os.version"]')
             docker manifest annotate --os windows --arch amd64 --os-version "${full_version}" \
               "${IMAGE}:${VERSION}" "${IMAGE}:${VERSION}-windows-${osversion}-amd64"
           done

--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -1,0 +1,369 @@
+# Publish csi-driver-smb container images and Helm chart to GHCR.
+#
+# Triggers:
+#   - Automatically on GitHub Release publish (tag must match v*)
+#   - Manually via workflow_dispatch with a version input
+#
+# Publishes:
+#   - Multi-arch container image: ghcr.io/kubernetes-csi/smbplugin:<version>
+#     (linux/amd64, linux/arm64, linux/ppc64le, linux/arm/v7,
+#      windows/amd64 1809, windows/amd64 ltsc2022)
+#   - Windows HostProcess image: ghcr.io/kubernetes-csi/smbplugin:<version>-windows-hp
+#   - Helm chart (OCI): oci://ghcr.io/kubernetes-csi/csi-driver-smb
+#
+name: Publish to GHCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., v1.20.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io/kubernetes-csi
+  IMAGE_NAME: smbplugin
+  CHART_NAME: csi-driver-smb
+  GO_VERSION: '1.25.0'
+
+jobs:
+  # ── Validate version and compute outputs ───────────────────────────────────
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      chart_version: ${{ steps.version.outputs.chart_version }}
+    steps:
+      - name: Determine and validate version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: '${VERSION}'. Expected: v<major>.<minor>.<patch> (e.g., v1.20.1)"
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION}"
+
+  # ── Build & push Linux container images ────────────────────────────────────
+  build-linux:
+    runs-on: ubuntu-latest
+    needs: [validate]
+    strategy:
+      matrix:
+        include:
+          - goarch: amd64
+            platform: linux/amd64
+            suffix: linux-amd64
+          - goarch: arm64
+            platform: linux/arm64
+            suffix: linux-arm64
+          - goarch: ppc64le
+            platform: linux/ppc64le
+            suffix: linux-ppc64le
+          - goarch: arm
+            goarm: '7'
+            platform: linux/arm/v7
+            suffix: linux-arm-v7
+    steps:
+      - name: Checkout at version tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.validate.outputs.version }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build binary
+        env:
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
+          CGO_ENABLED: '0'
+          GOOS: linux
+        run: |
+          GIT_COMMIT=$(git rev-parse HEAD)
+          mkdir -p _output/${{ matrix.goarch }}
+          go build -trimpath -ldflags="-s -w \
+            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=${{ needs.validate.outputs.version }} \
+            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
+            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o _output/${{ matrix.goarch }}/smbplugin ./cmd/smbplugin
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.platform }}
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          GIT_COMMIT=$(git rev-parse HEAD)
+          docker buildx build --push \
+            --platform=${{ matrix.platform }} \
+            --build-arg ARCH=${{ matrix.goarch }} \
+            --provenance=false --sbom=false \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-${{ matrix.suffix }} \
+            --label org.opencontainers.image.revision=${GIT_COMMIT} \
+            --file ./cmd/smbplugin/Dockerfile \
+            .
+
+  # ── Build & push Windows container images ──────────────────────────────────
+  # Cross-compile Go binary on Linux, then build the Windows container image
+  # on a Windows runner (required for pulling Windows base images).
+  build-windows:
+    needs: [validate]
+    strategy:
+      matrix:
+        include:
+          - osversion: '1809'
+            runner: windows-2019
+          - osversion: 'ltsc2022'
+            runner: windows-2022
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout at version tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.validate.outputs.version }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build Windows binary
+        shell: bash
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: '0'
+        run: |
+          GIT_COMMIT=$(git rev-parse HEAD)
+          mkdir -p _output/amd64
+          go build -trimpath -ldflags="-s -w \
+            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=${{ needs.validate.outputs.version }} \
+            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
+            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o _output/amd64/smbplugin.exe ./cmd/smbplugin
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push windows/${{ matrix.osversion }}
+        shell: bash
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          GIT_COMMIT=$(git rev-parse HEAD)
+          TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-windows-${{ matrix.osversion }}-amd64"
+          docker build \
+            --build-arg OSVERSION=${{ matrix.osversion }} \
+            --label org.opencontainers.image.revision=${GIT_COMMIT} \
+            --tag "${TAG}" \
+            --file ./cmd/smbplugin/Dockerfile.Windows \
+            .
+          docker push "${TAG}"
+
+  # ── Build & push Windows HostProcess image ─────────────────────────────────
+  build-windows-hp:
+    needs: [validate]
+    runs-on: windows-2022
+    steps:
+      - name: Checkout at version tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.validate.outputs.version }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build Windows binary
+        shell: bash
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: '0'
+        run: |
+          GIT_COMMIT=$(git rev-parse HEAD)
+          mkdir -p _output/amd64
+          go build -trimpath -ldflags="-s -w \
+            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=${{ needs.validate.outputs.version }} \
+            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
+            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o _output/amd64/smbplugin.exe ./cmd/smbplugin
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Windows HostProcess image
+        shell: bash
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          GIT_COMMIT=$(git rev-parse HEAD)
+          TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-windows-hp"
+          docker build \
+            --label org.opencontainers.image.revision=${GIT_COMMIT} \
+            --tag "${TAG}" \
+            --file ./cmd/smbplugin/Dockerfile.WindowsHostProcess \
+            .
+          docker push "${TAG}"
+
+  # ── Create multi-arch manifest ─────────────────────────────────────────────
+  manifest:
+    runs-on: ubuntu-latest
+    needs: [validate, build-linux, build-windows]
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
+
+          docker manifest create "${IMAGE}:${VERSION}" \
+            "${IMAGE}:${VERSION}-linux-amd64" \
+            "${IMAGE}:${VERSION}-linux-arm64" \
+            "${IMAGE}:${VERSION}-linux-arm-v7" \
+            "${IMAGE}:${VERSION}-linux-ppc64le" \
+            "${IMAGE}:${VERSION}-windows-1809-amd64" \
+            "${IMAGE}:${VERSION}-windows-ltsc2022-amd64"
+
+          # Annotate windows images with os.version for proper platform matching
+          for osversion in 1809 ltsc2022; do
+            BASEIMAGE="mcr.microsoft.com/windows/nanoserver:${osversion}"
+            full_version=$(docker manifest inspect "${BASEIMAGE}" | jq -r '.manifests[0].platform["os.version"]')
+            docker manifest annotate --os windows --arch amd64 --os-version "${full_version}" \
+              "${IMAGE}:${VERSION}" "${IMAGE}:${VERSION}-windows-${osversion}-amd64"
+          done
+
+          docker manifest push -p "${IMAGE}:${VERSION}"
+          echo "Pushed manifest: ${IMAGE}:${VERSION}"
+
+  # ── Publish Helm chart as OCI (independent of image builds) ────────────────
+  publish-helm:
+    runs-on: ubuntu-latest
+    needs: [validate]
+    steps:
+      - name: Checkout at version tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.validate.outputs.version }}
+
+      - name: Validate chart directory
+        run: |
+          CHART_DIR="charts/${{ needs.validate.outputs.version }}/${CHART_NAME}"
+          if [[ ! -f "${CHART_DIR}/Chart.yaml" ]]; then
+            echo "::error::Chart not found at ${CHART_DIR}/Chart.yaml"
+            echo "Available chart versions:"
+            ls -1 charts/ | grep '^v' || echo "  (none)"
+            exit 1
+          fi
+          echo "chart_dir=${CHART_DIR}" >> "$GITHUB_ENV"
+
+      - name: Setup Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+        with:
+          version: v3.17.0
+
+      - name: Lint chart
+        run: helm lint "${{ env.chart_dir }}"
+
+      - name: Verify chart version matches
+        run: |
+          YAML_VERSION=$(grep '^version:' "${{ env.chart_dir }}/Chart.yaml" | awk '{print $2}')
+          EXPECTED="${{ needs.validate.outputs.chart_version }}"
+          # Handle older charts that may have leading 'v' in Chart.yaml version
+          YAML_VERSION_STRIPPED="${YAML_VERSION#v}"
+          if [[ "$YAML_VERSION_STRIPPED" != "$EXPECTED" ]]; then
+            echo "::error::Chart.yaml version ($YAML_VERSION) != expected ($EXPECTED)"
+            exit 1
+          fi
+          echo "helm_chart_version=${YAML_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Login to GHCR (Helm)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+
+      - name: Package and push chart
+        run: |
+          helm package "${{ env.chart_dir }}" --destination /tmp/helm-pkg
+          PACKAGE=$(ls /tmp/helm-pkg/${CHART_NAME}-*.tgz)
+          helm push "${PACKAGE}" "oci://${REGISTRY}"
+
+      - name: Verify published chart
+        run: |
+          helm show chart "oci://${REGISTRY}/${CHART_NAME}" \
+            --version "${{ env.helm_chart_version }}"
+
+  # ── Summary ────────────────────────────────────────────────────────────────
+  summary:
+    runs-on: ubuntu-latest
+    needs: [validate, manifest, build-windows-hp, publish-helm]
+    if: always()
+    steps:
+      - name: Job summary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          CHART_VERSION: ${{ needs.validate.outputs.chart_version }}
+        shell: bash
+        run: |
+          FENCE='```'
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## Published to GHCR
+
+          ### Container Images
+          | Image | Tag |
+          |-------|-----|
+          | ${REGISTRY}/${IMAGE_NAME} | ${VERSION} (multi-arch manifest) |
+          | ${REGISTRY}/${IMAGE_NAME} | ${VERSION}-windows-hp (HostProcess) |
+
+          ${FENCE}bash
+          docker pull ${REGISTRY}/${IMAGE_NAME}:${VERSION}
+          docker pull ${REGISTRY}/${IMAGE_NAME}:${VERSION}-windows-hp
+          ${FENCE}
+
+          ### Helm Chart (OCI)
+          ${FENCE}bash
+          helm install csi-driver-smb oci://${REGISTRY}/${CHART_NAME} --version ${CHART_VERSION} -n kube-system
+          ${FENCE}
+          EOF
+          sed -i 's/^          //' "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate]
     outputs:
-      helm_chart_version: ${{ steps.verify-version.outputs.helm_chart_version }}
+      helm_chart_version: ${{ steps.verify_version.outputs.helm_chart_version }}
     steps:
       - name: Checkout at version tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -324,7 +324,7 @@ jobs:
         run: helm lint "${{ steps.chart.outputs.chart_dir }}"
 
       - name: Verify chart version matches
-        id: verify-version
+        id: verify_version
         run: |
           YAML_VERSION=$(grep '^version:' "${{ steps.chart.outputs.chart_dir }}/Chart.yaml" | awk '{print $2}')
           EXPECTED="${{ needs.validate.outputs.chart_version }}"
@@ -351,7 +351,7 @@ jobs:
       - name: Verify published chart
         run: |
           helm show chart "oci://${REGISTRY}/${CHART_NAME}" \
-            --version "${{ steps.verify-version.outputs.helm_chart_version }}"
+            --version "${{ steps.verify_version.outputs.helm_chart_version }}"
 
   # ── Summary ────────────────────────────────────────────────────────────────
   summary:

--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -304,6 +304,7 @@ jobs:
           ref: ${{ needs.validate.outputs.version }}
 
       - name: Validate chart directory
+        id: chart
         run: |
           CHART_DIR="charts/${{ needs.validate.outputs.version }}/${CHART_NAME}"
           if [[ ! -f "${CHART_DIR}/Chart.yaml" ]]; then
@@ -312,7 +313,7 @@ jobs:
             ls -1 charts/ | grep '^v' || echo "  (none)"
             exit 1
           fi
-          echo "chart_dir=${CHART_DIR}" >> "$GITHUB_ENV"
+          echo "chart_dir=${CHART_DIR}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
@@ -320,12 +321,12 @@ jobs:
           version: v3.17.0
 
       - name: Lint chart
-        run: helm lint "${{ env.chart_dir }}"
+        run: helm lint "${{ steps.chart.outputs.chart_dir }}"
 
       - name: Verify chart version matches
         id: verify-version
         run: |
-          YAML_VERSION=$(grep '^version:' "${{ env.chart_dir }}/Chart.yaml" | awk '{print $2}')
+          YAML_VERSION=$(grep '^version:' "${{ steps.chart.outputs.chart_dir }}/Chart.yaml" | awk '{print $2}')
           EXPECTED="${{ needs.validate.outputs.chart_version }}"
           # Handle older charts that may have leading 'v' in Chart.yaml version
           YAML_VERSION_STRIPPED="${YAML_VERSION#v}"
@@ -343,7 +344,7 @@ jobs:
 
       - name: Package and push chart
         run: |
-          helm package "${{ env.chart_dir }}" --destination /tmp/helm-pkg
+          helm package "${{ steps.chart.outputs.chart_dir }}" --destination /tmp/helm-pkg
           PACKAGE=$(ls /tmp/helm-pkg/${CHART_NAME}-*.tgz)
           helm push "${PACKAGE}" "oci://${REGISTRY}"
 


### PR DESCRIPTION
## What
Add GitHub Actions workflow (`.github/workflows/publish-helm-oci.yaml`) that builds multi-arch container images and publishes the Helm chart as an OCI artifact to GHCR.

## Published artifacts
| Artifact | Location |
|----------|----------|
| Container image | `ghcr.io/kubernetes-csi/smbplugin:<version>` (linux/amd64, arm64, arm/v7, ppc64le + windows/amd64 1809, ltsc2022) |
| Windows HostProcess image | `ghcr.io/kubernetes-csi/smbplugin:<version>-windows-hp` |
| Helm chart (OCI) | `oci://ghcr.io/kubernetes-csi/csi-driver-smb` |

## Triggers

### Automatic (on release)
When a GitHub Release is published with a `v*` tag, the workflow automatically builds images, creates a multi-arch manifest, and pushes the Helm chart.

### Manual (workflow_dispatch)
Maintainers can manually trigger from the Actions tab by providing a version (e.g., `v1.20.1`). Useful for backfilling historical versions or re-publishing.

## Workflow structure
1. **validate** — Early version format check (`v<major>.<minor>.<patch>`)
2. **build-linux** — Cross-compile Go binary + `docker buildx build` for each arch (parallel)
3. **build-windows** — Cross-compile + build on Windows runners (windows-2019 for 1809, windows-2022 for ltsc2022)
4. **build-windows-hp** — Windows HostProcess image on windows-2022
5. **manifest** — Create and push multi-arch manifest with Windows os.version annotations
6. **publish-helm** — Package and push Helm chart as OCI (independent of image builds)
7. **summary** — Job summary with install commands

## Install
```bash
# Container image
docker pull ghcr.io/kubernetes-csi/smbplugin:v1.20.1
docker pull ghcr.io/kubernetes-csi/smbplugin:v1.20.1-windows-hp

# Helm chart
helm install csi-driver-smb oci://ghcr.io/kubernetes-csi/csi-driver-smb --version 1.20.1 -n kube-system
```

Related: https://github.com/kubernetes-csi/csi-driver-smb/issues/1076