### PR TITLE
feat: build all Windows images on Ubuntu runners

### DIFF
--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -145,18 +145,19 @@ jobs:
             .
 
   # ── Build & push Windows container images ──────────────────────────────────
-  # Build Go binary and container image on Windows runners
-  # (required for pulling Windows base images).
+  # The Windows Dockerfiles only COPY a pre-built .exe into a Windows base
+  # image — no Windows-native build steps. Using docker buildx with
+  # --platform=windows/amd64 on Ubuntu avoids expensive Windows runners.
   build-windows:
+    runs-on: ubuntu-latest
     needs: [validate]
     strategy:
       matrix:
         include:
           - osversion: '1809'
-            runner: windows-2019
+            suffix: windows-1809-amd64
           - osversion: 'ltsc2022'
-            runner: windows-2022
-    runs-on: ${{ matrix.runner }}
+            suffix: windows-ltsc2022-amd64
     steps:
       - name: Checkout at version tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -168,8 +169,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Build Windows binary
-        shell: bash
+      - name: Cross-compile Windows binary
         env:
           GOOS: windows
           GOARCH: amd64
@@ -182,6 +182,9 @@ jobs:
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             -mod vendor -o _output/amd64/smbplugin.exe ./cmd/smbplugin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
       - name: Login to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
@@ -191,23 +194,23 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push windows/${{ matrix.osversion }}
-        shell: bash
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
           GIT_COMMIT=$(git rev-parse HEAD)
-          TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-windows-${{ matrix.osversion }}-amd64"
-          docker build --pull \
+          TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-${{ matrix.suffix }}"
+          docker buildx build --pull --push \
+            --platform=windows/amd64 \
             --build-arg OSVERSION=${{ matrix.osversion }} \
+            --provenance=false --sbom=false \
             --label org.opencontainers.image.revision=${GIT_COMMIT} \
             --tag "${TAG}" \
             --file ./cmd/smbplugin/Dockerfile.Windows \
             .
-          docker push "${TAG}"
 
-  # ── Build & push Windows HostProcess image ─────────────────────────────────
+  # ── Build & push Windows HostProcess image (cross-built on Ubuntu) ─────────
   build-windows-hp:
+    runs-on: ubuntu-latest
     needs: [validate]
-    runs-on: windows-2022
     steps:
       - name: Checkout at version tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -219,8 +222,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Build Windows binary
-        shell: bash
+      - name: Cross-compile Windows binary
         env:
           GOOS: windows
           GOARCH: amd64
@@ -234,6 +236,9 @@ jobs:
             -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             -mod vendor -o _output/amd64/smbplugin.exe ./cmd/smbplugin
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
       - name: Login to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
@@ -242,17 +247,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Windows HostProcess image
-        shell: bash
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
           GIT_COMMIT=$(git rev-parse HEAD)
           TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-windows-hp"
-          docker build --pull \
+          docker buildx build --pull --push \
+            --platform=windows/amd64 \
+            --provenance=false --sbom=false \
             --label org.opencontainers.image.revision=${GIT_COMMIT} \
             --tag "${TAG}" \
             --file ./cmd/smbplugin/Dockerfile.WindowsHostProcess \
             .
-          docker push "${TAG}"
 
   # ── Create multi-arch manifest ─────────────────────────────────────────────
   manifest:

--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -358,10 +358,34 @@ jobs:
           helm show chart "oci://${REGISTRY}/${CHART_NAME}" \
             --version "${{ steps.verify_version.outputs.helm_chart_version }}"
 
+  # ── Ensure GHCR packages are public ─────────────────────────────────────────
+  set-visibility:
+    runs-on: ubuntu-latest
+    needs: [manifest, build-windows-hp, publish-helm]
+    if: needs.manifest.result == 'success' || needs.build-windows-hp.result == 'success' || needs.publish-helm.result == 'success'
+    steps:
+      - name: Set container package visibility to public
+        if: needs.manifest.result == 'success'
+        run: |
+          curl -s -X PATCH \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${IMAGE_NAME}" \
+            -d '{"visibility":"public"}' || echo "::warning::Failed to set container package visibility (may need manual setup)"
+
+      - name: Set Helm chart package visibility to public
+        if: needs.publish-helm.result == 'success'
+        run: |
+          curl -s -X PATCH \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${CHART_NAME}" \
+            -d '{"visibility":"public"}' || echo "::warning::Failed to set Helm chart package visibility (may need manual setup)"
+
   # ── Summary ────────────────────────────────────────────────────────────────
   summary:
     runs-on: ubuntu-latest
-    needs: [validate, manifest, build-windows-hp, publish-helm]
+    needs: [validate, manifest, build-windows-hp, publish-helm, set-visibility]
     if: always()
     steps:
       - name: Job summary


### PR DESCRIPTION
## What
Switch Windows and Windows HostProcess image builds from Windows runners (`windows-2019`/`windows-2022`) to Ubuntu runners with `docker buildx --platform=windows/amd64`.

## Why
The Windows Dockerfiles (`Dockerfile.Windows` and `Dockerfile.WindowsHostProcess`) only `COPY` a pre-built `.exe` into Windows base images — no Windows-native build steps required. Using `docker buildx` on Ubuntu with `--platform=windows/amd64` handles cross-platform image creation at the layer level.

**Benefits:**
- Eliminates dependency on expensive Windows runners
- Faster startup (Ubuntu runners boot in seconds vs minutes)
- Cross-compilation via `GOOS=windows` on Linux is well-supported
- All build jobs now run on `ubuntu-latest` for consistency

## Changes
- `build-windows`: `windows-2019`/`windows-2022` runners → `ubuntu-latest` + `docker buildx build --platform=windows/amd64`
- `build-windows-hp`: `windows-2022` → `ubuntu-latest` + `docker buildx build --platform=windows/amd64`
- `docker build` → `docker buildx build --push` (eliminates separate push step)
- Added `--provenance=false --sbom=false` flags for consistency with Linux builds

Related: https://github.com/kubernetes-csi/csi-driver-smb/issues/1076