### PR TITLE
feat: publish Helm chart to GHCR as OCI artifact

### DIFF
--- a/.github/workflows/publish-helm-oci.yaml
+++ b/.github/workflows/publish-helm-oci.yaml
@@ -1,17 +1,16 @@
-# Publish csi-driver-smb container images and Helm chart to GHCR.
+# Publish csi-driver-smb Helm chart to GHCR as an OCI artifact.
 #
 # Triggers:
 #   - Automatically on GitHub Release publish (tag must match v*)
 #   - Manually via workflow_dispatch with a version input
 #
 # Publishes:
-#   - Multi-arch container image: ghcr.io/kubernetes-csi/smbplugin:<version>
-#     (linux/amd64, linux/arm64, linux/ppc64le, linux/arm/v7,
-#      windows/amd64 1809, windows/amd64 ltsc2022)
-#   - Windows HostProcess image: ghcr.io/kubernetes-csi/smbplugin:<version>-windows-hp
 #   - Helm chart (OCI): oci://ghcr.io/kubernetes-csi/csi-driver-smb
 #
-name: Publish to GHCR
+# Container images remain at registry.k8s.io/sig-storage/smbplugin
+# and are published via the existing release-tools/prow pipeline.
+#
+name: Publish Helm chart to GHCR
 
 on:
   release:
@@ -29,12 +28,10 @@ permissions:
 
 env:
   REGISTRY: ghcr.io/kubernetes-csi
-  IMAGE_NAME: smbplugin
   CHART_NAME: csi-driver-smb
-  GO_VERSION: '1.25.10'
 
 jobs:
-  # ── Validate version and compute outputs ───────────────────────────────────
+  # ── Validate version ──────────────────────────────────────────────────────
   validate:
     runs-on: ubuntu-latest
     outputs:
@@ -51,7 +48,7 @@ jobs:
           fi
 
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version format: '${VERSION}'. Expected: v<major>.<minor>.<patch> (e.g., v1.20.1)"
+            echo "::error::Invalid version format: '${VERSION}'. Expected: v<major>.<minor>.<patch>"
             exit 1
           fi
 
@@ -59,239 +56,7 @@ jobs:
           echo "chart_version=${VERSION#v}" >> "$GITHUB_OUTPUT"
           echo "Version: ${VERSION}"
 
-  # ── Build & push Linux container images ────────────────────────────────────
-  build-linux:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    strategy:
-      matrix:
-        include:
-          - goarch: amd64
-            platform: linux/amd64
-            suffix: linux-amd64
-          - goarch: arm64
-            platform: linux/arm64
-            suffix: linux-arm64
-          - goarch: ppc64le
-            platform: linux/ppc64le
-            suffix: linux-ppc64le
-          - goarch: arm
-            goarm: '7'
-            platform: linux/arm/v7
-            suffix: linux-arm-v7
-    steps:
-      - name: Checkout at version tag
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ needs.validate.outputs.version }}
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Build binary
-        env:
-          GOARCH: ${{ matrix.goarch }}
-          GOARM: ${{ matrix.goarm }}
-          CGO_ENABLED: '0'
-          GOOS: linux
-        run: |
-          # Use the same output path convention as Makefile:
-          # _output/<goarch>/smbplugin for most arches, _output/arm/v7/smbplugin for armv7
-          if [[ "${{ matrix.goarch }}" == "arm" ]]; then
-            OUT_DIR="_output/arm/v7"
-          else
-            OUT_DIR="_output/${{ matrix.goarch }}"
-          fi
-          GIT_COMMIT=$(git rev-parse HEAD)
-          mkdir -p "${OUT_DIR}"
-          go build -a -ldflags "-s -w \
-            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=${{ needs.validate.outputs.version }} \
-            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
-            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -mod vendor -o "${OUT_DIR}/smbplugin" ./cmd/smbplugin
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push ${{ matrix.platform }}
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          # Match Makefile convention: --build-arg ARCH=arm/v7 for armv7
-          if [[ "${{ matrix.goarch }}" == "arm" ]]; then
-            DOCKER_ARCH="arm/v7"
-          else
-            DOCKER_ARCH="${{ matrix.goarch }}"
-          fi
-          GIT_COMMIT=$(git rev-parse HEAD)
-          docker buildx build --pull --push \
-            --platform=${{ matrix.platform }} \
-            --build-arg ARCH=${DOCKER_ARCH} \
-            --provenance=false --sbom=false \
-            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-${{ matrix.suffix }} \
-            --label org.opencontainers.image.revision=${GIT_COMMIT} \
-            --file ./cmd/smbplugin/Dockerfile \
-            .
-
-  # ── Build & push Windows container images ──────────────────────────────────
-  # Build Go binary and container image on Windows runners
-  # (required for pulling Windows base images).
-  build-windows:
-    needs: [validate]
-    strategy:
-      matrix:
-        include:
-          - osversion: '1809'
-            runner: windows-2019
-          - osversion: 'ltsc2022'
-            runner: windows-2022
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Checkout at version tag
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ needs.validate.outputs.version }}
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Build Windows binary
-        shell: bash
-        env:
-          GOOS: windows
-          GOARCH: amd64
-          CGO_ENABLED: '0'
-        run: |
-          GIT_COMMIT=$(git rev-parse HEAD)
-          mkdir -p _output/amd64
-          go build -a -ldflags "-s -w \
-            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=${{ needs.validate.outputs.version }} \
-            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
-            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -mod vendor -o _output/amd64/smbplugin.exe ./cmd/smbplugin
-
-      - name: Login to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push windows/${{ matrix.osversion }}
-        shell: bash
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          GIT_COMMIT=$(git rev-parse HEAD)
-          TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-windows-${{ matrix.osversion }}-amd64"
-          docker build --pull \
-            --build-arg OSVERSION=${{ matrix.osversion }} \
-            --label org.opencontainers.image.revision=${GIT_COMMIT} \
-            --tag "${TAG}" \
-            --file ./cmd/smbplugin/Dockerfile.Windows \
-            .
-          docker push "${TAG}"
-
-  # ── Build & push Windows HostProcess image ─────────────────────────────────
-  build-windows-hp:
-    needs: [validate]
-    runs-on: windows-2022
-    steps:
-      - name: Checkout at version tag
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ needs.validate.outputs.version }}
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Build Windows binary
-        shell: bash
-        env:
-          GOOS: windows
-          GOARCH: amd64
-          CGO_ENABLED: '0'
-        run: |
-          GIT_COMMIT=$(git rev-parse HEAD)
-          mkdir -p _output/amd64
-          go build -a -ldflags "-s -w \
-            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.driverVersion=${{ needs.validate.outputs.version }} \
-            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.gitCommit=${GIT_COMMIT} \
-            -X github.com/kubernetes-csi/csi-driver-smb/pkg/smb.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -mod vendor -o _output/amd64/smbplugin.exe ./cmd/smbplugin
-
-      - name: Login to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Windows HostProcess image
-        shell: bash
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          GIT_COMMIT=$(git rev-parse HEAD)
-          TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-windows-hp"
-          docker build --pull \
-            --label org.opencontainers.image.revision=${GIT_COMMIT} \
-            --tag "${TAG}" \
-            --file ./cmd/smbplugin/Dockerfile.WindowsHostProcess \
-            .
-          docker push "${TAG}"
-
-  # ── Create multi-arch manifest ─────────────────────────────────────────────
-  manifest:
-    runs-on: ubuntu-latest
-    needs: [validate, build-linux, build-windows]
-    steps:
-      - name: Login to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create and push multi-arch manifest
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          IMAGE="${REGISTRY}/${IMAGE_NAME}"
-
-          docker manifest create "${IMAGE}:${VERSION}" \
-            "${IMAGE}:${VERSION}-linux-amd64" \
-            "${IMAGE}:${VERSION}-linux-arm64" \
-            "${IMAGE}:${VERSION}-linux-arm-v7" \
-            "${IMAGE}:${VERSION}-linux-ppc64le" \
-            "${IMAGE}:${VERSION}-windows-1809-amd64" \
-            "${IMAGE}:${VERSION}-windows-ltsc2022-amd64"
-
-          # Annotate windows images with os.version for proper platform matching
-          for osversion in 1809 ltsc2022; do
-            BASEIMAGE="mcr.microsoft.com/windows/nanoserver:${osversion}"
-            full_version=$(docker manifest inspect "${BASEIMAGE}" | \
-              jq -r '.manifests[] | select(.platform.architecture=="amd64") | .platform["os.version"]')
-            docker manifest annotate --os windows --arch amd64 --os-version "${full_version}" \
-              "${IMAGE}:${VERSION}" "${IMAGE}:${VERSION}-windows-${osversion}-amd64"
-          done
-
-          docker manifest push -p "${IMAGE}:${VERSION}"
-          echo "Pushed manifest: ${IMAGE}:${VERSION}"
-
-  # ── Publish Helm chart as OCI (independent of image builds) ────────────────
+  # ── Publish Helm chart as OCI ──────────────────────────────────────────────
   publish-helm:
     runs-on: ubuntu-latest
     needs: [validate]
@@ -306,11 +71,17 @@ jobs:
       - name: Validate chart directory
         id: chart
         run: |
-          CHART_DIR="charts/${{ needs.validate.outputs.version }}/${CHART_NAME}"
+          VERSION="${{ needs.validate.outputs.version }}"
+          CHART_DIR="charts/${VERSION}/${CHART_NAME}"
+          # Fallback: some versions store the chart under charts/latest/
           if [[ ! -f "${CHART_DIR}/Chart.yaml" ]]; then
-            echo "::error::Chart not found at ${CHART_DIR}/Chart.yaml"
-            echo "Available chart versions:"
-            ls -1 charts/ | grep '^v' || echo "  (none)"
+            CHART_DIR="charts/latest/${CHART_NAME}"
+          fi
+          if [[ ! -f "${CHART_DIR}/Chart.yaml" ]]; then
+            echo "::error::Chart not found for ${VERSION}"
+            echo "Searched: charts/${VERSION}/${CHART_NAME} and charts/latest/${CHART_NAME}"
+            echo "Available chart directories:"
+            ls -1 charts/ || echo "  (none)"
             exit 1
           fi
           echo "chart_dir=${CHART_DIR}" >> "$GITHUB_OUTPUT"
@@ -326,15 +97,13 @@ jobs:
       - name: Verify chart version matches
         id: verify_version
         run: |
-          YAML_VERSION=$(grep '^version:' "${{ steps.chart.outputs.chart_dir }}/Chart.yaml" | awk '{print $2}')
+          YAML_VERSION=$(helm show chart "${{ steps.chart.outputs.chart_dir }}" | grep '^version:' | awk '{print $2}')
           EXPECTED="${{ needs.validate.outputs.chart_version }}"
-          # Handle older charts that may have leading 'v' in Chart.yaml version
           YAML_VERSION_STRIPPED="${YAML_VERSION#v}"
           if [[ "$YAML_VERSION_STRIPPED" != "$EXPECTED" ]]; then
             echo "::error::Chart.yaml version ($YAML_VERSION) != expected ($EXPECTED)"
             exit 1
           fi
-          echo "helm_chart_version=${YAML_VERSION}" >> "$GITHUB_ENV"
           echo "helm_chart_version=${YAML_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR (Helm)
@@ -353,35 +122,17 @@ jobs:
           helm show chart "oci://${REGISTRY}/${CHART_NAME}" \
             --version "${{ steps.verify_version.outputs.helm_chart_version }}"
 
-  # ── Summary ────────────────────────────────────────────────────────────────
-  summary:
-    runs-on: ubuntu-latest
-    needs: [validate, manifest, build-windows-hp, publish-helm]
-    if: always()
-    steps:
       - name: Job summary
         env:
-          VERSION: ${{ needs.validate.outputs.version }}
-          CHART_VERSION: ${{ needs.publish-helm.outputs.helm_chart_version || needs.validate.outputs.chart_version }}
-        shell: bash
+          CHART_VERSION: ${{ steps.verify_version.outputs.helm_chart_version }}
         run: |
           FENCE='```'
           {
-            echo "## Published to GHCR"
+            echo "## ✅ Helm Chart Published to GHCR"
             echo ""
-            echo "### Container Images"
-            echo "| Image | Tag |"
-            echo "|-------|-----|"
-            echo "| ${REGISTRY}/${IMAGE_NAME} | ${VERSION} (multi-arch manifest) |"
-            echo "| ${REGISTRY}/${IMAGE_NAME} | ${VERSION}-windows-hp (HostProcess) |"
-            echo ""
-            echo "${FENCE}bash"
-            echo "docker pull ${REGISTRY}/${IMAGE_NAME}:${VERSION}"
-            echo "docker pull ${REGISTRY}/${IMAGE_NAME}:${VERSION}-windows-hp"
-            echo "${FENCE}"
-            echo ""
-            echo "### Helm Chart (OCI)"
             echo "${FENCE}bash"
             echo "helm install csi-driver-smb oci://${REGISTRY}/${CHART_NAME} --version ${CHART_VERSION} -n kube-system"
             echo "${FENCE}"
+            echo ""
+            echo "> Container images remain at \`registry.k8s.io/sig-storage/smbplugin\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What
Add a GitHub Actions workflow to publish the csi-driver-smb Helm chart to GHCR as an OCI artifact.

## Why
Helm OCI support is GA since Helm 3.8. Publishing charts to GHCR provides a standard OCI registry distribution alongside the existing methods. See https://github.com/kubernetes-csi/csi-driver-smb/issues/1076

## What this PR does NOT do
- Does NOT build or publish container images — those remain at `registry.k8s.io/sig-storage/smbplugin` via the existing release-tools/prow pipeline
- Does NOT change any existing workflows

## Helm chart location
```bash
helm install csi-driver-smb oci://ghcr.io/kubernetes-csi/csi-driver-smb --version <chart_version> -n kube-system
```

## Triggers
- **Automatic**: on GitHub Release publish (tag must match `v*`)
- **Manual**: via `workflow_dispatch` with version input (for backfilling older releases)

## Features
- Version validation (`v<major>.<minor>.<patch>` format)
- Chart lint before publish
- Chart.yaml version verification
- Post-publish verification via `helm show chart`
- Fallback to `charts/latest/` directory
- All GitHub Actions pinned to immutable SHAs

Related: https://github.com/kubernetes-csi/csi-driver-smb/issues/1076