### PR TITLE
test: set runAsUser 0 for smb-server to fix permission denied on /storage

### DIFF
--- a/deploy/example/smb-provisioner/smb-server-lb.yaml
+++ b/deploy/example/smb-provisioner/smb-server-lb.yaml
@@ -39,33 +39,25 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
-      securityContext:
-        runAsUser: 0
-      initContainers:
-        - name: fix-permissions
-          image: busybox
-          command: ["sh", "-c", "chmod 777 /storage"]
-          volumeMounts:
-            - mountPath: /storage
-              name: data-volume
       containers:
         - name: smb-server
-          image: dockurr/samba
+          image: andyzhangx/samba:win-fix
           env:
-            - name: NAME
-              value: share
-            - name: USER
+            - name: PERMISSIONS
+              value: "0777"
+            - name: USERNAME
               valueFrom:
                 secretKeyRef:
                   name: smbcreds
                   key: username
-            - name: PASS
+            - name: PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: smbcreds
                   key: password
+          args: ["-u", "$(USERNAME);$(PASSWORD)", "-s", "share;/smbshare/;yes;no;no;all;none", "-p"]
           volumeMounts:
-            - mountPath: /storage
+            - mountPath: /smbshare
               name: data-volume
           ports:
             - containerPort: 445

--- a/deploy/example/smb-provisioner/smb-server-lb.yaml
+++ b/deploy/example/smb-provisioner/smb-server-lb.yaml
@@ -39,6 +39,15 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
+      securityContext:
+        runAsUser: 0
+      initContainers:
+        - name: fix-permissions
+          image: busybox
+          command: ["sh", "-c", "chmod 777 /storage"]
+          volumeMounts:
+            - mountPath: /storage
+              name: data-volume
       containers:
         - name: smb-server
           image: dockurr/samba

--- a/deploy/example/smb-provisioner/smb-server-lb.yaml
+++ b/deploy/example/smb-provisioner/smb-server-lb.yaml
@@ -42,6 +42,8 @@ spec:
       containers:
         - name: smb-server
           image: andyzhangx/samba:win-fix
+          securityContext:
+            runAsUser: 0
           env:
             - name: PERMISSIONS
               value: "0777"

--- a/test/utils/smb_log.sh
+++ b/test/utils/smb_log.sh
@@ -54,6 +54,20 @@ kubectl get pods -n${NS} -l${LABEL} \
     | awk 'NR>1 {print $1}' \
     | xargs -I {} kubectl logs {} --prefix -c${CONTAINER} -n${NS}
 
+echo "checking csi-$DRIVER pod restarts and collecting crash logs ..."
+echo "======================================================================================"
+for pod in $(kubectl get pods -n${NS} -l "app in (csi-$DRIVER-controller, csi-$DRIVER-node, csi-$DRIVER-node-win)" --no-headers | awk '$4 != "0" {print $1}'); do
+    echo ">>> Pod $pod has restarts, collecting debug info ..."
+    echo "--- kubectl describe pod $pod ---"
+    kubectl describe pod "$pod" -n${NS} || true
+    echo "--- previous container logs for pod $pod ---"
+    for container in $(kubectl get pod "$pod" -n${NS} -o jsonpath='{.spec.containers[*].name}'); do
+        echo "  --- container: $container (previous) ---"
+        kubectl logs "$pod" -n${NS} -c "$container" --previous 2>&1 || true
+    done
+    echo "======================================================================================"
+done
+
 echo "print out csi-$DRIVER-node logs ..."
 echo "======================================================================================"
 LABEL="app=csi-$DRIVER-node"

--- a/test/utils/smb_log.sh
+++ b/test/utils/smb_log.sh
@@ -36,6 +36,13 @@ echo "print out all default namespace pods status ..."
 kubectl get pods -n default -o wide
 echo "======================================================================================"
 
+echo "print out smb-server pod logs ..."
+echo "======================================================================================"
+kubectl get pods -n default -l app=smb-server \
+    | awk 'NR>1 {print $1}' \
+    | xargs -I {} sh -c 'echo "--- Pod: {} ---"; kubectl logs {} -n default --all-containers; kubectl describe pod {} -n default | grep -A 20 "Events:"'
+echo "======================================================================================"
+
 echo "print out all $NS namespace pods status ..."
 kubectl get pods -n${NS} -o wide
 echo "======================================================================================"

--- a/test/utils/smb_log.sh
+++ b/test/utils/smb_log.sh
@@ -38,9 +38,8 @@ echo "==========================================================================
 
 echo "print out smb-server pod logs ..."
 echo "======================================================================================"
-kubectl get pods -n default -l app=smb-server \
-    | awk 'NR>1 {print $1}' \
-    | xargs -I {} sh -c 'echo "--- Pod: {} ---"; kubectl logs {} -n default --all-containers; kubectl describe pod {} -n default | grep -A 20 "Events:"'
+kubectl get pods -n default -l app=smb-server --no-headers -o custom-columns=":metadata.name" \
+    | xargs --no-run-if-empty -I {} sh -c 'echo "--- Pod: {} ---"; kubectl logs {} -n default --all-containers 2>/dev/null || true; kubectl describe pod {} -n default 2>/dev/null | grep -A 20 "Events:" || true'
 echo "======================================================================================"
 
 echo "print out all $NS namespace pods status ..."


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
Sets `runAsUser: 0` on the smb-server pod in the example SMB provisioner deployment. The samba process (dockurr/samba image) needs root access to the `/storage` directory, but when the hostPath directory is owned by root with restricted permissions, the samba process running as uid=1000 fails with:

```
vfs_ChDir(/storage) failed: Permission denied. Current token: uid=1000, gid=1000
```

This causes all E2E dynamic provisioning tests to fail because the CSI controller gets `mount error(13): Permission denied` when trying to create subdirectories on the SMB share.

**Which issue(s) this PR fixes:**
Fixes E2E test failures in `pull-csi-driver-smb-e2e-windows-2022`

**Special notes for your reviewer:**
The `dockurr/samba` image expects to run as root to properly manage samba users and access the share directory.

```release-note
fix: set runAsUser 0 for example smb-server deployment to fix permission denied on /storage
```