### PR TITLE
Update csi-release-tools for release-1.20

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           check_filenames: true

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get Go version
         id: go-version

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ images. Building from master creates the main `canary` image.
 Sharing and updating
 --------------------
 
-[`git subtree`](https://github.com/git/git/blob/HEAD/contrib/subtree/git-subtree.txt)
+[`git subtree`](https://github.com/git/git/blob/HEAD/contrib/subtree/git-subtree.adoc)
 is the recommended way of maintaining a copy of the rules inside the
 `release-tools` directory of a project. This way, it is possible to make
 changes also locally, test them and then push them back to the shared

--- a/verify-spelling.sh
+++ b/verify-spelling.sh
@@ -50,7 +50,7 @@ RES=0
 echo "Checking spelling..."
 ERROR_LOG="${TMP_DIR}/errors.log"
 cd "${ROOT}"
-git ls-files | grep -v vendor | xargs misspell > "${ERROR_LOG}"
+git ls-files -z | grep -z -v vendor | xargs -0 misspell -- > "${ERROR_LOG}"
 if [[ -s "${ERROR_LOG}" ]]; then
   sed 's/^/error: /' "${ERROR_LOG}" # add 'error' to each line to highlight in e2e status
   echo "Found spelling errors!"


### PR DESCRIPTION
Update release-tools subtree from csi-release-tools master.

```
git subtree pull --squash --prefix=release-tools https://github.com/kubernetes-csi/csi-release-tools.git master
```