### PR TITLE
cleanup: add validation on volumeid

### DIFF
--- a/pkg/smb/controllerserver.go
+++ b/pkg/smb/controllerserver.go
@@ -549,13 +549,20 @@ func getSmbVolFromID(id string) (*smbVolume, error) {
 	if !strings.HasPrefix(segments[0], "//") {
 		source = "//" + source
 	}
+	subDir := segments[1]
+	if err := validatePath(subDir); err != nil {
+		return nil, fmt.Errorf("invalid subDir %q: %v", subDir, err)
+	}
 	vol := &smbVolume{
 		id:     id,
 		source: source,
-		subDir: segments[1],
+		subDir: subDir,
 	}
 	if len(segments) >= 3 {
 		vol.uuid = segments[2]
+		if err := validatePath(vol.uuid); err != nil {
+			return nil, fmt.Errorf("invalid uuid %q: %v", vol.uuid, err)
+		}
 	}
 	if len(segments) >= 4 {
 		vol.onDelete = segments[3]

--- a/pkg/smb/controllerserver_test.go
+++ b/pkg/smb/controllerserver_test.go
@@ -558,6 +558,16 @@ func TestGetSmbVolFromID(t *testing.T) {
 			subDir:    "pvc-4729891a-f57e-4982-9c60-e9884af1be2f",
 			expectErr: true,
 		},
+		{
+			desc:      "subDir with path traversal should be rejected",
+			volumeID:  "smb-server.default.svc.cluster.local/share#../../etc/shadow#pvc-4729891a-f57e-4982-9c60-e9884af1be2f",
+			expectErr: true,
+		},
+		{
+			desc:      "uuid with path traversal should be rejected",
+			volumeID:  "smb-server.default.svc.cluster.local/share#subdir#../../etc/shadow#delete",
+			expectErr: true,
+		},
 	}
 	for _, test := range cases {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds additional input validation when parsing CSI volume IDs to reduce the risk of unsafe filesystem path construction.

Changes:
- Add `validatePath()` validation for the `subDir` and `uuid` segments in `getSmbVolFromID()`, to be consistent with the existing validation on `source` and `subDir` fields in `newSMBVolume()`.
- Add unit tests ensuring `subDir` and `uuid` path traversal (e.g. `../../...`) are rejected.

**Which issue(s) this PR fixes**:
NONE

**Requirements**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
NONE
```