### PR TITLE
chore(deps): bump github/codeql-action init+analyze from 4.36.2 to 4.36.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This driver allows Kubernetes to use [SMB](https://wiki.wireshark.org/SMB) CSI v
 Please refer to [`smb.csi.k8s.io` driver parameters](./docs/driver-parameters.md)
 
 ### Install smb CSI driver on a kubernetes cluster
-Please refer to [install smb csi driver](https://github.com/csi-driver/csi-driver-smb/blob/master/docs/install-csi-driver-smb.md)
+Please refer to [install smb csi driver](./docs/install-csi-driver-master.md)
 
 ### Examples
  - [Basic usage](./deploy/example/e2e_usage.md)

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -26,3 +26,5 @@ csi-smb-node-dr4s4                        3/3     Running   0          7m4s    1
 ```console
 $ kubectl logs csi-smb-node-cvgbs -c smb -n kube-system > csi-smb-node.log
 ```
+
+ - get `/var/log/messages` and `dmesg` output when there is mount failure on Linux node

--- a/docs/install-csi-driver-master.md
+++ b/docs/install-csi-driver-master.md
@@ -1,4 +1,4 @@
-## Install smb CSI driver development version on a Kubernetes cluster
+## Install SMB CSI driver development version on a Kubernetes cluster
 
 ### Install by kubectl
 ```console


### PR DESCRIPTION
**What this PR does / why we need it:**

Bumps [`github/codeql-action`](https://github.com/github/codeql-action) `init` **and** `analyze` from `4.36.2` (`8aad20d`) to `4.36.3` (`54f647b`) in a single commit.

Dependabot's #1141 bumps only `analyze`. Merging it on its own leaves `init` and `analyze` at mismatched versions, and CodeQL fails at the `analyze` step with:

```
Error: Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

`init` writes a config file tagged with its own version and `analyze` refuses to run when the two don't match. Both must be bumped together.

Closes #1141.

**Special notes for your reviewer:**

Same fix as kubernetes-csi/csi-driver-nfs#1186, kubernetes-csi/csi-driver-iscsi#436, kubernetes-sigs/sig-storage-local-static-provisioner#579, kubernetes-sigs/azuredisk-csi-driver#3686, kubernetes-sigs/azurefile-csi-driver#3239, and kubernetes-sigs/blob-csi-driver#2531.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
