### PR TITLE
bump github/codeql-action init+analyze from 4.37.1 to 4.37.3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4


### PR DESCRIPTION
What this PR does / why we need it:

Bumps [github/codeql-action](https://github.com/github/codeql-action) init and analyze from 4.37.1 (7188fc3) to 4.37.3 (e4fba86) in a single commit.

Both init and analyze must be bumped together — init writes a config file tagged with its own version and analyze refuses to run when the two do not match.

**Does this PR introduce a user-facing change?**

NONE