### PR TITLE
fix: prevent goroutine leak on Windows mount timeout

### DIFF
--- a/pkg/smb/fake_mounter_test.go
+++ b/pkg/smb/fake_mounter_test.go
@@ -17,12 +17,110 @@ limitations under the License.
 package smb
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	mount "k8s.io/mount-utils"
 )
+
+// slowMounter wraps fakeMounter and blocks MountSensitive for a configurable
+// duration. Used by TestMountWithTimeout to exercise timeout / lock semantics.
+type slowMounter struct {
+	fakeMounter
+	delay time.Duration
+}
+
+func (s *slowMounter) MountSensitive(source, target, _ string, _ []string, _ []string) error {
+	time.Sleep(s.delay)
+	return s.fakeMounter.MountSensitive(source, target, "", nil, nil)
+}
+
+func TestMountWithTimeout(t *testing.T) {
+	tests := []struct {
+		name           string
+		mountDelay     time.Duration
+		timeout        time.Duration
+		wantKeepLock   bool
+		wantCode       codes.Code
+		wantErr        bool
+		checkLockAsync bool // verify lock is released asynchronously
+	}{
+		{
+			name:         "mount completes before timeout",
+			mountDelay:   0,
+			timeout:      time.Second,
+			wantKeepLock: false,
+			wantErr:      false,
+		},
+		{
+			name:           "mount times out, lock held and released async",
+			mountDelay:     500 * time.Millisecond,
+			timeout:        50 * time.Millisecond,
+			wantKeepLock:   true,
+			wantCode:       codes.DeadlineExceeded,
+			wantErr:        true,
+			checkLockAsync: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewFakeDriver()
+			d.mounter = &mount.SafeFormatAndMount{
+				Interface: &slowMounter{delay: tc.mountDelay},
+			}
+
+			lockKey := "test-lock"
+			if !d.volumeLocks.TryAcquire(lockKey) {
+				t.Fatal("failed to acquire volume lock")
+			}
+
+			ctx := context.Background()
+			keepLock, err := d.mountWithTimeout(ctx, "source", "/target", nil, nil, "vol-1", lockKey, tc.timeout)
+
+			if keepLock != tc.wantKeepLock {
+				t.Errorf("keepLockHeld = %v, want %v", keepLock, tc.wantKeepLock)
+			}
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("expected gRPC status error, got %v", err)
+				}
+				if st.Code() != tc.wantCode {
+					t.Errorf("error code = %v, want %v", st.Code(), tc.wantCode)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if tc.checkLockAsync {
+				// Lock should be held right now (retry should fail)
+				if d.volumeLocks.TryAcquire(lockKey) {
+					t.Error("expected lock to be held after timeout, but TryAcquire succeeded")
+					d.volumeLocks.Release(lockKey)
+				}
+				// Wait for the mount goroutine to finish and release the lock
+				time.Sleep(tc.mountDelay + 200*time.Millisecond)
+				if !d.volumeLocks.TryAcquire(lockKey) {
+					t.Error("expected lock to be released after mount goroutine finished")
+				} else {
+					d.volumeLocks.Release(lockKey)
+				}
+			} else if !keepLock {
+				// When keepLock is false, caller releases the lock — just clean up
+				d.volumeLocks.Release(lockKey)
+			}
+		})
+	}
+}
 
 func TestMount(t *testing.T) {
 	targetTest := "./target_test"

--- a/pkg/smb/fake_mounter_test.go
+++ b/pkg/smb/fake_mounter_test.go
@@ -113,12 +113,20 @@ func TestMountWithTimeout(t *testing.T) {
 					t.Error("expected lock to be held after timeout, but TryAcquire succeeded")
 					d.volumeLocks.Release(lockKey)
 				}
-				// Wait for the mount goroutine to finish and release the lock
-				time.Sleep(tc.mountDelay + 200*time.Millisecond)
-				if !d.volumeLocks.TryAcquire(lockKey) {
+				// Poll for the async lock release with an overall deadline so
+				// we wait just long enough on slow CI runners without flaking.
+				deadline := time.Now().Add(tc.mountDelay + 5*time.Second)
+				acquired := false
+				for time.Now().Before(deadline) {
+					if d.volumeLocks.TryAcquire(lockKey) {
+						acquired = true
+						d.volumeLocks.Release(lockKey)
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				if !acquired {
 					t.Error("expected lock to be released after mount goroutine finished")
-				} else {
-					d.volumeLocks.Release(lockKey)
 				}
 			} else if !keepLock {
 				// When keepLock is false, caller releases the lock — just clean up

--- a/pkg/smb/fake_mounter_test.go
+++ b/pkg/smb/fake_mounter_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -41,6 +42,11 @@ func (s *slowMounter) MountSensitive(source, target, _ string, _ []string, _ []s
 }
 
 func TestMountWithTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows Mount() requires a real CSIProxyMounter; the timeout logic
+		// under test is platform-agnostic and covered on Linux.
+		t.Skip("skipping on windows: Mount() requires csi-proxy mounter")
+	}
 	tests := []struct {
 		name           string
 		mountDelay     time.Duration

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -354,7 +354,10 @@ func (d *Driver) mountWithTimeout(ctx context.Context, source, targetPath string
 
 	deferReleaseLock := func(reason string) {
 		go func() {
-			<-mountDone
+			mountErr := <-mountDone
+			if mountErr != nil {
+				klog.Warningf("volume(%s) mount %q on %q failed after %s with %v", volumeID, source, targetPath, reason, mountErr)
+			}
 			d.volumeLocks.Release(lockKey)
 			klog.V(2).Infof("volume(%s) mount goroutine finished after %s, released lock", volumeID, reason)
 		}()

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -216,7 +216,12 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	if acquired := d.volumeLocks.TryAcquire(lockKey); !acquired {
 		return nil, status.Errorf(codes.Aborted, volumeOperationAlreadyExistsFmt, volumeID)
 	}
-	defer d.volumeLocks.Release(lockKey)
+	releaseLock := true
+	defer func() {
+		if releaseLock {
+			d.volumeLocks.Release(lockKey)
+		}
+	}()
 
 	var username, password, domain string
 	for k, v := range secrets {
@@ -311,14 +316,26 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		if err := validatePath(source); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid source path %q: %v", source, err)
 		}
-		execFunc := func() error {
-			return Mount(d.mounter, source, targetPath, "cifs", mountOptions, sensitiveMountOptions, volumeID)
-		}
-		timeoutFunc := func() error {
-			return fmt.Errorf("mount volume %s to %s timeout after %ds", source, targetPath, mountTimeoutInSec)
-		}
-		if err := util.WaitUntilTimeout(mountTimeoutInSec*time.Second, execFunc, timeoutFunc); err != nil {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %q on %q failed with %v", volumeID, source, targetPath, err))
+		mountDone := make(chan error, 1)
+		go func() {
+			mountDone <- Mount(d.mounter, source, targetPath, "cifs", mountOptions, sensitiveMountOptions, volumeID)
+		}()
+		select {
+		case err := <-mountDone:
+			if err != nil {
+				return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %q on %q failed with %v", volumeID, source, targetPath, err))
+			}
+		case <-time.After(time.Duration(mountTimeoutInSec) * time.Second):
+			// The mount goroutine is still running; keep the volume lock held
+			// so kubelet retries get codes.Aborted instead of spawning more
+			// goroutines. Release the lock asynchronously when the mount finishes.
+			releaseLock = false
+			go func() {
+				<-mountDone
+				d.volumeLocks.Release(lockKey)
+				klog.V(2).Infof("volume(%s) mount goroutine finished after timeout, released lock", volumeID)
+			}()
+			return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %q on %q timeout after %ds", volumeID, source, targetPath, mountTimeoutInSec))
 		}
 		klog.V(2).Infof("volume(%s) mount %q on %q succeeded", volumeID, source, targetPath)
 	}

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -18,6 +18,7 @@ package smb
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -321,7 +322,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			releaseLock = false
 		}
 		if mountErr != nil {
-			return nil, status.Errorf(codes.Internal, "volume(%s) mount %q on %q failed with %v", volumeID, source, targetPath, mountErr)
+			return nil, mountErr
 		}
 		klog.V(2).Infof("volume(%s) mount %q on %q succeeded", volumeID, source, targetPath)
 	}
@@ -336,6 +337,12 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 // background goroutine releases the lock once the mount goroutine eventually
 // returns. This prevents kubelet retries from spawning additional mount
 // goroutines against the same target while a slow mount is still in flight.
+//
+// Returned errors are already wrapped in gRPC status errors:
+//   - mount failure                            -> codes.Internal
+//   - timer expired                            -> codes.DeadlineExceeded
+//   - ctx canceled with DeadlineExceeded cause -> codes.DeadlineExceeded
+//   - ctx canceled (client canceled)           -> codes.Canceled
 func (d *Driver) mountWithTimeout(ctx context.Context, source, targetPath string, mountOptions, sensitiveMountOptions []string, volumeID, lockKey string, timeout time.Duration) (keepLockHeld bool, err error) {
 	mountDone := make(chan error, 1)
 	go func() {
@@ -355,13 +362,20 @@ func (d *Driver) mountWithTimeout(ctx context.Context, source, targetPath string
 
 	select {
 	case mountErr := <-mountDone:
-		return false, mountErr
+		if mountErr != nil {
+			return false, status.Errorf(codes.Internal, "volume(%s) mount %q on %q failed with %v", volumeID, source, targetPath, mountErr)
+		}
+		return false, nil
 	case <-timer.C:
 		deferReleaseLock("timeout")
-		return true, fmt.Errorf("mount %q on %q timeout after %v", source, targetPath, timeout)
+		return true, status.Errorf(codes.DeadlineExceeded, "volume(%s) mount %q on %q timeout after %v", volumeID, source, targetPath, timeout)
 	case <-ctx.Done():
 		deferReleaseLock("context cancellation")
-		return true, fmt.Errorf("mount %q on %q canceled: %v", source, targetPath, ctx.Err())
+		code := codes.Canceled
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			code = codes.DeadlineExceeded
+		}
+		return true, status.Errorf(code, "volume(%s) mount %q on %q canceled: %v", volumeID, source, targetPath, ctx.Err())
 	}
 }
 

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -367,9 +367,29 @@ func (d *Driver) mountWithTimeout(ctx context.Context, source, targetPath string
 		}
 		return false, nil
 	case <-timer.C:
+		// Re-check mountDone non-blocking: select picks randomly among
+		// ready cases, so the mount may have completed at the same instant
+		// the timer fired.
+		select {
+		case mountErr := <-mountDone:
+			if mountErr != nil {
+				return false, status.Errorf(codes.Internal, "volume(%s) mount %q on %q failed with %v", volumeID, source, targetPath, mountErr)
+			}
+			return false, nil
+		default:
+		}
 		deferReleaseLock("timeout")
 		return true, status.Errorf(codes.DeadlineExceeded, "volume(%s) mount %q on %q timeout after %v", volumeID, source, targetPath, timeout)
 	case <-ctx.Done():
+		// Re-check mountDone: mount may have completed simultaneously.
+		select {
+		case mountErr := <-mountDone:
+			if mountErr != nil {
+				return false, status.Errorf(codes.Internal, "volume(%s) mount %q on %q failed with %v", volumeID, source, targetPath, mountErr)
+			}
+			return false, nil
+		default:
+		}
 		deferReleaseLock("context cancellation")
 		code := codes.Canceled
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {

--- a/pkg/smb/nodeserver.go
+++ b/pkg/smb/nodeserver.go
@@ -316,31 +316,53 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		if err := validatePath(source); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid source path %q: %v", source, err)
 		}
-		mountDone := make(chan error, 1)
-		go func() {
-			mountDone <- Mount(d.mounter, source, targetPath, "cifs", mountOptions, sensitiveMountOptions, volumeID)
-		}()
-		select {
-		case err := <-mountDone:
-			if err != nil {
-				return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %q on %q failed with %v", volumeID, source, targetPath, err))
-			}
-		case <-time.After(time.Duration(mountTimeoutInSec) * time.Second):
-			// The mount goroutine is still running; keep the volume lock held
-			// so kubelet retries get codes.Aborted instead of spawning more
-			// goroutines. Release the lock asynchronously when the mount finishes.
+		keepLockHeld, mountErr := d.mountWithTimeout(ctx, source, targetPath, mountOptions, sensitiveMountOptions, volumeID, lockKey, time.Duration(mountTimeoutInSec)*time.Second)
+		if keepLockHeld {
 			releaseLock = false
-			go func() {
-				<-mountDone
-				d.volumeLocks.Release(lockKey)
-				klog.V(2).Infof("volume(%s) mount goroutine finished after timeout, released lock", volumeID)
-			}()
-			return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %q on %q timeout after %ds", volumeID, source, targetPath, mountTimeoutInSec))
+		}
+		if mountErr != nil {
+			return nil, status.Errorf(codes.Internal, "volume(%s) mount %q on %q failed with %v", volumeID, source, targetPath, mountErr)
 		}
 		klog.V(2).Infof("volume(%s) mount %q on %q succeeded", volumeID, source, targetPath)
 	}
 
 	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+// mountWithTimeout runs Mount in a goroutine and waits for it to finish, the
+// gRPC context to be canceled, or the configured mount timeout to elapse. When
+// the mount is still running after the wait ends (timeout or ctx cancellation),
+// it returns keepLockHeld=true so the caller keeps the volume lock; a
+// background goroutine releases the lock once the mount goroutine eventually
+// returns. This prevents kubelet retries from spawning additional mount
+// goroutines against the same target while a slow mount is still in flight.
+func (d *Driver) mountWithTimeout(ctx context.Context, source, targetPath string, mountOptions, sensitiveMountOptions []string, volumeID, lockKey string, timeout time.Duration) (keepLockHeld bool, err error) {
+	mountDone := make(chan error, 1)
+	go func() {
+		mountDone <- Mount(d.mounter, source, targetPath, "cifs", mountOptions, sensitiveMountOptions, volumeID)
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	deferReleaseLock := func(reason string) {
+		go func() {
+			<-mountDone
+			d.volumeLocks.Release(lockKey)
+			klog.V(2).Infof("volume(%s) mount goroutine finished after %s, released lock", volumeID, reason)
+		}()
+	}
+
+	select {
+	case mountErr := <-mountDone:
+		return false, mountErr
+	case <-timer.C:
+		deferReleaseLock("timeout")
+		return true, fmt.Errorf("mount %q on %q timeout after %v", source, targetPath, timeout)
+	case <-ctx.Done():
+		deferReleaseLock("context cancellation")
+		return true, fmt.Errorf("mount %q on %q canceled: %v", source, targetPath, ctx.Err())
+	}
 }
 
 // NodeUnstageVolume unmount the volume from the staging path


### PR DESCRIPTION
## What this PR does

When `NodeStageVolume` times out waiting for a Windows SMB mount (e.g. due to wrong path or credentials), the mount goroutine continues running but the volume lock was released via `defer`. This allowed kubelet retries to spawn additional mount goroutines, eventually exhausting kubelet resources and causing a crash (node goes NotReady).

## Root Cause

`WaitUntilTimeout` spawns a goroutine for the mount but returns on timeout without cancelling it. Meanwhile, `defer d.volumeLocks.Release(lockKey)` releases the lock, so the next kubelet retry acquires it and spawns yet another goroutine. Over time (minutes), dozens of leaked goroutines accumulate holding Windows CSI-proxy SMB connections, exhausting memory/handles.

## Fix

Replace `WaitUntilTimeout` with an inline channel-based timeout that **keeps the volume lock held** when the mount goroutine is still running. Kubelet retries get `codes.Aborted` immediately (no new goroutines). The lock is released asynchronously when the hung mount finally completes.

**Before:** Each timeout → lock released → retry spawns new goroutine → crash
**After:** Each timeout → lock held → retry gets Aborted → only 1 goroutine per volume

Fixes #1080

/kind bug