### PR TITLE
docs(charts): document GitHub Pages helm repo as an additional install option

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -20,7 +20,7 @@ Add the helm repo (pick either source — both host the same charts):
 # Option 1: raw.githubusercontent.com (default)
 helm repo add csi-driver-smb https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts
 
-# Option 2: GitHub Pages mirror (available since 1.20.3, not affected by raw.githubusercontent.com rate limits)
+# Option 2: GitHub Pages mirror (available since 1.20.0, not affected by raw.githubusercontent.com rate limits)
 helm repo add csi-driver-smb https://kubernetes-csi.github.io/csi-driver-smb
 ```
 
@@ -28,7 +28,7 @@ Then update the repo cache, search for available versions, and install:
 
 ```console
 helm repo update csi-driver-smb
-helm search repo csi-driver-smb
+helm search repo csi-driver-smb --versions
 helm install csi-driver-smb csi-driver-smb/csi-driver-smb --namespace kube-system --version 1.20.3
 ```
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -14,13 +14,17 @@
 > [!IMPORTANT]  
 > Starting from version `1.18.0`, the prefix `v` is removed from helm chart release so they are in line with [semver](https://semver.org). Therefore, when upgrading, refer to version `1.18.0` instead of `v1.18.0`.
 
-Add the helm repo (pick either source — both host the same charts):
+Add the helm repo — pick **one** source (both host the same charts; do not run both, the second overwrites the first):
+
+Option 1: raw.githubusercontent.com (default)
 
 ```console
-# Option 1: raw.githubusercontent.com (default)
 helm repo add csi-driver-smb https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts
+```
 
-# Option 2: GitHub Pages mirror (available since 1.20.0, not affected by raw.githubusercontent.com rate limits)
+Option 2: GitHub Pages mirror (available since 1.20.0, not affected by raw.githubusercontent.com rate limits)
+
+```console
 helm repo add csi-driver-smb https://kubernetes-csi.github.io/csi-driver-smb
 ```
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -14,8 +14,21 @@
 > [!IMPORTANT]  
 > Starting from version `1.18.0`, the prefix `v` is removed from helm chart release so they are in line with [semver](https://semver.org). Therefore, when upgrading, refer to version `1.18.0` instead of `v1.18.0`.
 
+Add the helm repo (pick either source — both host the same charts):
+
 ```console
+# Option 1: raw.githubusercontent.com (default)
 helm repo add csi-driver-smb https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts
+
+# Option 2: GitHub Pages mirror (available since 1.20.3, not affected by raw.githubusercontent.com rate limits)
+helm repo add csi-driver-smb https://kubernetes-csi.github.io/csi-driver-smb
+```
+
+Then update the repo cache, search for available versions, and install:
+
+```console
+helm repo update csi-driver-smb
+helm search repo csi-driver-smb
 helm install csi-driver-smb csi-driver-smb/csi-driver-smb --namespace kube-system --version 1.20.3
 ```
 


### PR DESCRIPTION
## What this PR does

Follow-up to #1170. Now that the chart is also published to `https://kubernetes-csi.github.io/csi-driver-smb` via GitHub Pages, document both install options in `charts/README.md`.

- **Option 1 (default, unchanged):** `https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts`
- **Option 2 (new, additive):** `https://kubernetes-csi.github.io/csi-driver-smb` — not subject to raw.githubusercontent.com rate limits

The raw.githubusercontent.com repository is **NOT deprecated**. Users can pick whichever is more reliable from their network.

## Testing

```console
helm repo add csi-driver-smb https://kubernetes-csi.github.io/csi-driver-smb
helm repo update csi-driver-smb
helm search repo csi-driver-smb
NAME                            CHART VERSION   APP VERSION     DESCRIPTION
csi-driver-smb/csi-driver-smb   1.20.3          1.20.3          CSI SMB Driver for Kubernetes
```

/kind documentation
/sig storage
/assign @andyzhangx