### PR TITLE
bump github/codeql-action init+analyze from 4.37.4 to 4.37.5

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+      uses: github/codeql-action/init@85689a103d1234521562bbb736b2c4a31c9a85d5 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+      uses: github/codeql-action/analyze@85689a103d1234521562bbb736b2c4a31c9a85d5 # v4


### PR DESCRIPTION
What this PR does / why we need it:

Bumps [github/codeql-action](https://github.com/github/codeql-action) init and analyze from 4.37.4 (f205ea1) to 4.37.5 (85689a1) in a single commit.

Both init and analyze must be bumped together — init writes a config file tagged with its own version and analyze refuses to run when the two do not match.

This follows the same pattern as #1176. It also fixes the incomplete analyze-only bump in #1177.

**Does this PR introduce a user-facing change?**

NONE
