### PR TITLE
chore: remove xfsprogs from smbplugin image

### DIFF
--- a/cmd/smbplugin/Dockerfile
+++ b/cmd/smbplugin/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.8
 
-RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs
+RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev
 
 LABEL maintainers="andyzhangx"
 LABEL description="SMB CSI Driver"


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it:
Remove `xfsprogs` from `cmd/smbplugin/Dockerfile`.

The SMB node plugin mounts CIFS shares and does not appear to use `xfs_*` userspace tools at runtime. Keeping the image minimal avoids carrying an unnecessary package and its transitive dependencies.

## Which issue(s) this PR fixes:
Part of investigating image vulnerability findings reported in #1181.

## Special notes for your reviewer:
This change is intentionally narrow: it only removes `xfsprogs` from the Linux `smbplugin` image package list.

## Does this PR introduce a user-facing change?
```release-note
NONE
```
