### PR TITLE
[WIP] build: self-build cifs-utils without python tools

### DIFF
--- a/cmd/smbplugin/Dockerfile
+++ b/cmd/smbplugin/Dockerfile
@@ -12,9 +12,65 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM debian:bookworm AS cifs-utils-builder
+
+ARG CIFS_UTILS_VERSION=7.0
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bzip2 \
+    build-essential \
+    ca-certificates \
+    curl \
+    libcap-ng-dev \
+    libkeyutils-dev \
+    libkrb5-dev \
+    libpam0g-dev \
+    libtalloc-dev \
+    libwbclient-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN curl -fsSLo cifs-utils.tar.bz2 https://www.samba.org/ftp/linux-cifs/cifs-utils/cifs-utils-${CIFS_UTILS_VERSION}.tar.bz2 \
+    && tar -xjf cifs-utils.tar.bz2 --strip-components=1
+
+RUN multiarch="$(gcc -print-multiarch)" \
+    && ./configure \
+        --enable-cifsidmap \
+        --enable-cifscreds \
+        --with-libcap-ng=auto \
+        --enable-pam \
+        --with-pamdir="/lib/${multiarch}/security" \
+        --enable-man=no \
+        --enable-smbinfo=no \
+        --disable-pythontools \
+    && make -j"$(nproc)" \
+    && make DESTDIR=/out install \
+    && install -d /out/etc/request-key.d /out/etc/cifs-utils \
+    && printf 'create  cifs.idmap    * * /usr/sbin/cifs.idmap %%k\n' > /out/etc/request-key.d/cifs.idmap.conf \
+    && printf 'create  cifs.spnego    * * /usr/sbin/cifs.upcall %%k\n' > /out/etc/request-key.d/cifs.spnego.conf \
+    && ln -sf "/usr/lib/${multiarch}/cifs-utils/idmapwb.so" /out/etc/cifs-utils/idmap-plugin \
+    && chmod u+s /out/sbin/mount.cifs
+
 FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.8
 
-RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs
+RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install \
+    ca-certificates \
+    e2fsprogs \
+    libcap-ng0 \
+    libgssapi-krb5-2 \
+    libkeyutils1 \
+    libkrb5-3 \
+    libpam0g \
+    libtalloc2 \
+    libwbclient0 \
+    mount \
+    udev \
+    util-linux \
+    xfsprogs
+
+COPY --from=cifs-utils-builder /out/ /
 
 LABEL maintainers="andyzhangx"
 LABEL description="SMB CSI Driver"


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it:
Build `cifs-utils` from source in `cmd/smbplugin/Dockerfile` instead of installing the Debian `cifs-utils` binary package.

The Debian bookworm package has a hard runtime dependency on `python3` because it ships Python helper tools such as `smbinfo` and `smb2-quota`. The SMB CSI node plugin does not use those tools at runtime, but they pull Python and related CVE findings into the image.

This change keeps the CIFS runtime pieces the plugin needs (`mount.cifs`, `cifs.upcall`, `cifs.idmap`, `idmapwb.so`, PAM module, request-key config) while disabling the Python-based helper tools during the source build:
- `--enable-smbinfo=no`
- `--disable-pythontools`

The build keeps the other Debian-style feature flags for the CIFS helpers (`cifsidmap`, `cifscreds`, `pam`, `libcap-ng`) and copies the built artifacts into the final runtime image.

## Which issue(s) this PR fixes:
Part of investigating image vulnerability findings reported in #1181.

## Special notes for your reviewer:
This is intentionally scoped to the Linux `smbplugin` image. The final image no longer installs the Debian `cifs-utils` package directly; instead it installs the runtime libraries needed by the built CIFS helpers and copies the built binaries/config into the image.

## Does this PR introduce a user-facing change?
```release-note
NONE
```
