### PR TITLE
chore: remove e2fsprogs from smbplugin image

### DIFF
--- a/cmd/smbplugin/Dockerfile
+++ b/cmd/smbplugin/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.8
 
-RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev
+RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates cifs-utils util-linux mount udev
 
 LABEL maintainers="andyzhangx"
 LABEL description="SMB CSI Driver"


### PR DESCRIPTION
## What this PR does
- removes `e2fsprogs` from `cmd/smbplugin/Dockerfile`

## Why
`e2fsprogs` is not needed in the SMB plugin image, so dropping it keeps the image a bit smaller and reduces unnecessary packages.