### PR TITLE
cleanup: demote empty GRPC response log to V(6)

### DIFF
--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -79,8 +79,17 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
-	} else {
-		klog.V(level).Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
+	} else if klog.V(level).Enabled() {
+		// Only serialize when the level is enabled so that high-frequency
+		// RPCs (Probe, NodeGetCapabilities) don't pay the JSON marshal cost.
+		// Empty responses (e.g. NodePublishVolume/NodeUnpublishVolume success)
+		// carry zero diagnostic value but dominate node logs; demote to V(6).
+		respStr := protosanitizer.StripSecrets(resp).String()
+		respLevel := level
+		if respStr == "{}" {
+			respLevel = klog.Level(6)
+		}
+		klog.V(respLevel).Infof("GRPC response: %s", respStr)
 	}
 	return resp, err
 }

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"flag"
+	"io"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -141,6 +142,77 @@ func TestLogGRPC(t *testing.T) {
 
 			// CLEANUP
 			buf.Reset()
+		})
+	}
+}
+
+func TestLogGRPCEmptyResponse(t *testing.T) {
+	buf := new(bytes.Buffer)
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
+	klog.SetOutput(buf)
+	defer klog.SetOutput(io.Discard)
+
+	vFlag := flag.Lookup("v")
+	var originalV string
+	if vFlag != nil {
+		originalV = vFlag.Value.String()
+		defer func() { _ = vFlag.Value.Set(originalV) }()
+	}
+	var vLevel klog.Level
+
+	info := grpc.UnaryServerInfo{FullMethod: "/csi.v1.Node/NodePublishVolume"}
+	req := &csi.NodePublishVolumeRequest{VolumeId: "vol_1"}
+
+	emptyHandler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+	nonEmptyHandler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return &csi.NodeGetInfoResponse{NodeId: "node-1"}, nil
+	}
+
+	tests := []struct {
+		name             string
+		v                string
+		handler          grpc.UnaryHandler
+		expectResponse   bool
+		expectedResponse string
+	}{
+		{
+			name:           "empty response is suppressed at V(2)",
+			v:              "2",
+			handler:        emptyHandler,
+			expectResponse: false,
+		},
+		{
+			name:             "empty response is visible at V(6)",
+			v:                "6",
+			handler:          emptyHandler,
+			expectResponse:   true,
+			expectedResponse: "GRPC response: {}",
+		},
+		{
+			name:             "non-empty response is still visible at V(2)",
+			v:                "2",
+			handler:          nonEmptyHandler,
+			expectResponse:   true,
+			expectedResponse: `GRPC response: {"node_id":"node-1"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_ = vLevel.Set(test.v)
+			buf.Reset()
+
+			_, _ = logGRPC(context.Background(), req, &info, test.handler)
+			klog.Flush()
+
+			if test.expectResponse {
+				assert.Contains(t, buf.String(), test.expectedResponse)
+			} else {
+				assert.NotContains(t, buf.String(), "GRPC response:")
+			}
 		})
 	}
 }


### PR DESCRIPTION
An empty response body (`{}`) carries zero diagnostic value but dominates
node logs: kubelet reconciles NodePublishVolume / NodeUnpublishVolume on
every sync loop, all of which return `{}` on success.

**Changes:**
- Demote the log to V(6) when the sanitized response is exactly `{}`.
  Non-empty responses and error paths are unchanged.
- Guard the serialization with `klog.V(level).Enabled()` so that
  disabled levels (e.g. Probe/NodeGetCapabilities at V(6) in production)
  no longer pay the protosanitizer JSON marshal cost on the hot path.
- Add `TestLogGRPCEmptyResponse` covering:
  - empty response suppressed at V(2)
  - empty response visible at V(6)
  - non-empty response still visible at V(2)

ref: https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/3772